### PR TITLE
Sc null prop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                
 =======
 
-###Latest AmberDb snapshot version : 1.1.245-SNAPSHOT
+###Latest AmberDb snapshot version : 1.1.246-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                
 =======
 
-###Latest AmberDb snapshot version : 1.1.246-SNAPSHOT
+###Latest AmberDb snapshot version : 1.1.247-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.245-SNAPSHOT</version>
+  <version>1.1.246-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>amberdb</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.246-SNAPSHOT</version>
+  <version>1.1.247-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>amberdb</name>

--- a/src/amberdb/graph/AmberEdgeQuery.java
+++ b/src/amberdb/graph/AmberEdgeQuery.java
@@ -178,8 +178,8 @@ public class AmberEdgeQuery extends AmberQueryBase {
             // run the generated query
             h.begin();
             h.execute(
-                    "DROP TABLE IF EXISTS ep; CREATE TEMPORARY TABLE ep (id BIGINT) " + graph.tempTableEngine + ";" +
-                    "DROP TABLE IF EXISTS vp; CREATE TEMPORARY TABLE vp (id BIGINT) " + graph.tempTableEngine + ";");
+                    "DROP " + graph.tempTableDrop + " TABLE IF EXISTS ep; CREATE TEMPORARY TABLE ep (id BIGINT) " + graph.tempTableEngine + ";" +
+                    "DROP " + graph.tempTableDrop + " TABLE IF EXISTS vp; CREATE TEMPORARY TABLE vp (id BIGINT) " + graph.tempTableEngine + ";");
             Update q = h.createStatement(generateQuery());
             
             for (int i = 0; i < properties.size(); i++) {

--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -48,6 +48,7 @@ public class AmberGraph extends BaseGraph
 
     String dbProduct;
     protected String tempTableEngine = "";
+    protected String tempTableDrop = "";
     
     protected Map<Object, Edge> removedEdges = new HashMap<>();
     protected Map<Object, Vertex> removedVertices = new HashMap<>();
@@ -120,6 +121,7 @@ public class AmberGraph extends BaseGraph
 
         if (dbProduct.equals("MySQL")) {
             tempTableEngine = "ENGINE=memory";
+            tempTableDrop = "TEMPORARY";
             return dbi.onDemand(AmberDaoMySql.class);
         } else if (dbProduct.equals("H2")) {
             return dbi.onDemand(AmberDaoH2.class);
@@ -460,10 +462,10 @@ public class AmberGraph extends BaseGraph
 
         // End current elements where this transaction modifies or deletes them.
         // Additionally, end edges orphaned by this procedure.
-        dao.endElements(txnId);
+        endElementsWithRetry(txnId, 5, 400);
         
         // start new elements for new and modified transaction elements
-        dao.startElements(txnId);
+        startElementsWithRetry(txnId, 5, 400);
         
         // Refactor note: need to check when adding (modding?) edges that both ends exist
         dao.insertTransaction(txnId, new Date().getTime(), user, operation);
@@ -728,6 +730,60 @@ public class AmberGraph extends BaseGraph
 
     public AmberTransaction getFirstTransactionForEdgeId(Long id) {
         return dao.getFirstTransactionForEdgeId(id);
+    }
+
+
+    private void endElementsWithRetry(Long txnId, int retries, int backoffDelay) {
+        int tryCount = 0;
+        int backoff = backoffDelay;
+        retryLoop: while (true) {
+            try {
+                dao.endElements(txnId);
+                break retryLoop;
+            } catch (RuntimeException e) {
+                if (tryCount < retries) {
+                    log.warn("AmberDb dao.endElements failed: Reason: {}\n" +
+                            "Retry after {} milliseconds", e.getMessage(), backoff);
+                    tryCount++;
+                    try {
+                        Thread.sleep(backoff);
+                    } catch (InterruptedException ie) {
+                        log.error("Backoff delay failed :", ie); // noted
+                    }
+                    backoff = backoff *2;
+                } else {
+                    log.error("AmberDb dao.endElements failed after {} retries: Reason:", retries, e);
+                    throw e;
+                }
+            }
+        }
+    }
+
+
+    private void startElementsWithRetry(Long txnId, int retries, int backoffDelay) {
+        int tryCount = 0;
+        int backoff = backoffDelay;
+        retryLoop: while (true) {
+            try {
+                dao.startElements(txnId);
+                break retryLoop;
+            } catch (RuntimeException e) {
+                if (tryCount < retries) {
+                    log.warn("AmberDb dao.startElements failed: Reason: {}\n" +
+                            "Retry after {} milliseconds", e.getMessage(), backoff);
+                    tryCount++;
+                    try {
+                        Thread.sleep(backoff);
+                    } catch (InterruptedException ie) {
+                        log.error("Backoff delay failed :", ie); // noted
+                    }
+                    backoff = backoff *2;
+                } else {
+                    log.error("AmberDb dao.startElements failed after {} retries: Reason:", retries, e);
+                    throw e;
+                }
+            }
+        }
     }
 }
 

--- a/src/amberdb/graph/AmberMultipartQuery.java
+++ b/src/amberdb/graph/AmberMultipartQuery.java
@@ -105,7 +105,7 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
     private String createTmpTables() {
 
         StringBuilder s = new StringBuilder();
-        s.append("DROP TABLE IF EXISTS v0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v0;\n");
         s.append("CREATE TEMPORARY TABLE v0 ("
                 + "step INT, "
                 + "vid BIGINT, "
@@ -116,7 +116,7 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
         // double buffer table to get around mysql limitation
         // of not being able to open the same temporary table
         // more than once in a query
-        s.append("DROP TABLE IF EXISTS v1;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v1;\n");
         s.append("CREATE TEMPORARY TABLE v1 ("
                 + "step INT, "
                 + "vid BIGINT, "

--- a/src/amberdb/graph/AmberPropertyBatch.java
+++ b/src/amberdb/graph/AmberPropertyBatch.java
@@ -18,9 +18,14 @@ public class AmberPropertyBatch {
     void add(Long id, Map<String, Object> properties) {
         if (properties == null) return;
         for (String name : properties.keySet()) {
+
+            // MySQL seems to map an empty string to null in a blob field context
+            // This should eliminate this issue by simply not saving the empty str
+            Object value = properties.get(name);
+            if (value.equals("")) continue;
+
             this.id.add(id);
             this.name.add(name);
-            Object value = properties.get(name);
             this.type.add(DataType.forObject(value));
             this.value.add(AmberProperty.encode(value));
         }

--- a/src/amberdb/graph/AmberQuery.java
+++ b/src/amberdb/graph/AmberQuery.java
@@ -126,7 +126,7 @@ public class AmberQuery extends AmberQueryBase {
         int step = 0;
         
         StringBuilder s = new StringBuilder();
-        s.append("DROP TABLE IF EXISTS v0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v0;\n");
         s.append("CREATE TEMPORARY TABLE v0 ("
                 + "step INT, "
                 + "vid BIGINT, "
@@ -137,7 +137,7 @@ public class AmberQuery extends AmberQueryBase {
         // double buffer table to get around mysql limitation
         // of not being able to open the same temporary table
         // more than once in a query
-        s.append("DROP TABLE IF EXISTS v1;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v1;\n");
         s.append("CREATE TEMPORARY TABLE v1 ("
                 + "step INT, "
                 + "vid BIGINT, "

--- a/src/amberdb/graph/AmberVertexQuery.java
+++ b/src/amberdb/graph/AmberVertexQuery.java
@@ -172,7 +172,7 @@ public class AmberVertexQuery extends AmberQueryBase {
 
             // run the generated query
             h.begin();
-            h.execute("DROP TABLE IF EXISTS vp; CREATE TEMPORARY TABLE vp (id BIGINT) " + graph.tempTableEngine + ";");
+            h.execute("DROP " + graph.tempTableDrop + " TABLE IF EXISTS vp; CREATE TEMPORARY TABLE vp (id BIGINT) " + graph.tempTableEngine + ";");
             Update q = h.createStatement(generateQuery());
             
             for (int i = 0; i < properties.size(); i++) {

--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -1052,7 +1052,10 @@ public interface Work extends Node {
      */
     @JavaHandler
     public void orderParts(List<Work> parts);
-
+    
+    @JavaHandler
+    public List<String> getJsonList(String propertyName) throws JsonParseException, JsonMappingException, IOException;
+    
     abstract class Impl extends Node.Impl implements JavaHandlerContext<Vertex>, Work {
         static ObjectMapper mapper = new ObjectMapper();
 
@@ -1362,6 +1365,11 @@ public interface Work extends Node {
             return mapper.writeValueAsString(list);
         }
 
+        @Override
+        public List<String> getJsonList(String propertyName) throws JsonParseException, JsonMappingException, IOException {
+            return deserialiseJSONString((String) this.asVertex().getProperty(propertyName));
+        }
+        
         @Override
         public void orderRelated(List<Work> relatedNodes, String label, Direction direction) {
             for (int i = 0; i < relatedNodes.size(); i++) {

--- a/src/amberdb/version/TransactionQuery.java
+++ b/src/amberdb/version/TransactionQuery.java
@@ -155,8 +155,8 @@ public class TransactionQuery {
         }
         
         StringBuilder s = new StringBuilder();
-        s.append("DROP TABLE IF EXISTS v0;\n");
-        s.append("DROP TABLE IF EXISTS e0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS e0;\n");
         
         s.append("CREATE TEMPORARY TABLE v0 (id BIGINT) " + graph.tempTableEngine + ";\n");
         s.append("CREATE TEMPORARY TABLE e0 (id BIGINT) " + graph.tempTableEngine + ";\n");
@@ -185,9 +185,9 @@ public class TransactionQuery {
 
     public String makeTempTablesQuery() {
         StringBuilder s = new StringBuilder();
-        s.append("DROP TABLE IF EXISTS c0;\n");
-        s.append("DROP TABLE IF EXISTS f0;\n");
-        s.append("DROP TABLE IF EXISTS d0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS c0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS f0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS d0;\n");
 
         s.append("CREATE TEMPORARY TABLE c0 (id BIGINT) " + graph.tempTableEngine + ";\n"); // Copies
         s.append("CREATE TEMPORARY TABLE f0 (id BIGINT) " + graph.tempTableEngine + ";\n"); // Files

--- a/src/amberdb/version/VersionQuery.java
+++ b/src/amberdb/version/VersionQuery.java
@@ -77,8 +77,8 @@ public class VersionQuery {
         int step = 0;
         
         StringBuilder s = new StringBuilder();
-        s.append("DROP TABLE IF EXISTS v0;\n");
-        s.append("DROP TABLE IF EXISTS v1;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v0;\n");
+        s.append("DROP " + graph.tempTableDrop + " TABLE IF EXISTS v1;\n");
         
         s.append("CREATE TEMPORARY TABLE v0 ("
                 + "step INT, "

--- a/src/amberdb/version/VersionedGraph.java
+++ b/src/amberdb/version/VersionedGraph.java
@@ -39,6 +39,7 @@ public class VersionedGraph {
 
     protected final DBI dbi;
     protected final String tempTableEngine;
+    protected final String tempTableDrop;
     private final VersionDao dao;
 
     private boolean localMode = false;
@@ -102,13 +103,14 @@ public class VersionedGraph {
         dao = this.dbi.onDemand(VersionDao.class);
         
         try (Handle h = dbi.open()) {
-        	String dbProduct;
-        	try {
-        		dbProduct = h.getConnection().getMetaData().getDatabaseProductName();
-			} catch (SQLException e) {
-				throw new RuntimeException("Unable to get database product name", e);
-			}
-			tempTableEngine = "MySQL".equals(dbProduct) ? "ENGINE=memory" : "";
+            String dbProduct;
+            try {
+                dbProduct = h.getConnection().getMetaData().getDatabaseProductName();
+            } catch (SQLException e) {
+                throw new RuntimeException("Unable to get database product name", e);
+            }
+            tempTableEngine = "MySQL".equals(dbProduct) ? "ENGINE=memory" : "";
+            tempTableDrop = "MySQL".equals(dbProduct) ? "TEMPORARY" : "";
         }
     }
         


### PR DESCRIPTION
Fix null properties being created when empty string properties are saved ('')
Allow MySQL read only connections to create temp tables for querying
Implemented retry for 'deadlocked' queries in AmberDb commit
