### PR TITLE
updated listUUIDs() for ead reload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                        
 =======
 
-###Latest AmberDb snapshot version : 1.1.284-SNAPSHOT 
+###Latest AmberDb snapshot version : 1.1.285-SNAPSHOT 
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.284-SNAPSHOT</version>
+  <version>1.1.285-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/model/builder/CollectionBuilder.java
+++ b/src/amberdb/model/builder/CollectionBuilder.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import nu.xom.Node;
@@ -182,7 +183,7 @@ public class CollectionBuilder {
         
         parser.init(collection.getObjId(), getFindingAIDFile(collection).openStream(), getDefaultCollectionCfg());
         Map<String, String> currentComponents = componentWorksMap(collection); 
-        List<String> eadUUIDList = parser.listUUIDs();
+        Set<String> eadUUIDList = parser.listUUIDs(currentComponents.size());
         List<String> componentsNotInEAD = new ArrayList<String>();
         
         for (String asId : currentComponents.keySet()) {

--- a/src/amberdb/model/builder/XmlDocumentParser.java
+++ b/src/amberdb/model/builder/XmlDocumentParser.java
@@ -3,8 +3,11 @@ package amberdb.model.builder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import nu.xom.Builder;
@@ -153,8 +156,8 @@ public abstract class XmlDocumentParser {
         return nodes;
     }
     
-    public List<String> listUUIDs() {
-        List<String> eadUUIDList = new ArrayList<String>();
+    public Set<String> listUUIDs(int estCapacity) {
+        Set<String> eadUUIDList = Collections.synchronizedSet(new HashSet<String>(estCapacity));
         JsonNode collectionCfg = parsingCfg;
         JsonNode subElementsCfg = collectionCfg.get(CFG_COLLECTION_ELEMENT).get(CFG_SUB_ELEMENTS);
         String repeatablePath = subElementsCfg.get(CFG_REPEATABLE_ELEMENTS).getTextValue();
@@ -165,7 +168,7 @@ public abstract class XmlDocumentParser {
         return eadUUIDList;
     }
 
-    private List<String> listUUIDs(List<String> eadUUIDList, JsonNode subElementsCfg, String repeatablePath,
+    private Set<String> listUUIDs(Set<String> eadUUIDList, JsonNode subElementsCfg, String repeatablePath,
             String componentBasePath, Nodes baseComponents) {
         if (baseComponents != null) {
             for (int i = 0; i < baseComponents.size(); i++) {
@@ -174,8 +177,7 @@ public abstract class XmlDocumentParser {
                 for (int j = 0; j < components.size(); j++) {
                     Map<String, String> fldsMap = getFieldsMap(components.get(j), subElementsCfg, componentBasePath);
                     String uuid = fldsMap.get("uuid").toString();
-                    if (!eadUUIDList.contains(uuid))
-                        eadUUIDList.add(uuid);
+                    eadUUIDList.add(uuid);
                     eadUUIDList = listUUIDs(eadUUIDList, subElementsCfg, repeatablePath, componentBasePath, components);
                 }
             }

--- a/src/amberdb/model/builder/XmlDocumentParser.java
+++ b/src/amberdb/model/builder/XmlDocumentParser.java
@@ -160,6 +160,13 @@ public abstract class XmlDocumentParser {
         String repeatablePath = subElementsCfg.get(CFG_REPEATABLE_ELEMENTS).getTextValue();
         String componentBasePath = subElementsCfg.get(CFG_BASE).getTextValue();
         Nodes baseComponents = getElementsByXPath(doc, componentBasePath);
+        eadUUIDList = listUUIDs(eadUUIDList, subElementsCfg, repeatablePath, componentBasePath, baseComponents);
+
+        return eadUUIDList;
+    }
+
+    private List<String> listUUIDs(List<String> eadUUIDList, JsonNode subElementsCfg, String repeatablePath,
+            String componentBasePath, Nodes baseComponents) {
         if (baseComponents != null) {
             for (int i = 0; i < baseComponents.size(); i++) {
                 Node baseComponent = baseComponents.get(i);
@@ -167,11 +174,12 @@ public abstract class XmlDocumentParser {
                 for (int j = 0; j < components.size(); j++) {
                     Map<String, String> fldsMap = getFieldsMap(components.get(j), subElementsCfg, componentBasePath);
                     String uuid = fldsMap.get("uuid").toString();
-                    eadUUIDList.add(uuid);
+                    if (!eadUUIDList.contains(uuid))
+                        eadUUIDList.add(uuid);
+                    eadUUIDList = listUUIDs(eadUUIDList, subElementsCfg, repeatablePath, componentBasePath, components);
                 }
             }
         }
-
         return eadUUIDList;
     }
     

--- a/test/amberdb/model/builder/CollectionBuilderTest.java
+++ b/test/amberdb/model/builder/CollectionBuilderTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.sql.DataSource;
 import nu.xom.Element;
@@ -393,7 +394,7 @@ public class CollectionBuilderTest {
             InputStream in = new FileInputStream(testEADPath.toFile());
             EADParser parser = new EADParser();
             parser.init(collectionWorkId, in, collectCfg);
-            List<String> uuids = parser.listUUIDs();
+            Set<String> uuids = parser.listUUIDs(10);
             assertTrue(!uuids.isEmpty());
             assertEquals(uuids.size(), 8);
         }

--- a/test/amberdb/model/builder/CollectionBuilderTest.java
+++ b/test/amberdb/model/builder/CollectionBuilderTest.java
@@ -318,7 +318,7 @@ public class CollectionBuilderTest {
             JsonNode statusReport = doc.getReport();
             assertNotNull(statusReport);
             assertNotNull(statusReport.get("eadUpdateReviewRequired"));
-            assertEquals(2, statusReport.get("eadUpdateReviewRequired").size());
+            assertEquals(1, statusReport.get("eadUpdateReviewRequired").size());
             as.commit();
             
             // verify the component of AS id (i.e. updatedCompAsId) is under the first component work 


### PR DESCRIPTION
listUUIDs() is expected to extract all UUIDs from an EAD ingest file for comparison with existing EAD works within a collection.  Currently, it's only extracting the first level of children from the file, and not traversing to all levels within the file.

This request provides the fix to extract all UUIDs from an EAD ingest file.