### PR TITLE
additional validation for invalid date when parsing date range.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.1.295-SNAPSHOT 
+###Latest AmberDb snapshot version : 1.1.296-SNAPSHOT 
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.295-SNAPSHOT</version>
+  <version>1.1.296-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/util/DateParser.java
+++ b/src/amberdb/util/DateParser.java
@@ -13,6 +13,7 @@ import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +69,11 @@ public class DateParser {
      *       for corresponding date extracted from the input date range expression. 
      */
     public static List<Date> parseDateRange(String dateRangeExpr) throws ParseException {
+        String numberInStrExpr = "(.*)?([0-9]+)(.*)?";
+        if (dateRangeExpr != null) dateRangeExpr = dateRangeExpr.trim();
+        if (!StringUtils.isEmpty(dateRangeExpr) && !dateRangeExpr.matches(numberInStrExpr)) {
+            throw new ParseException("Invalid date expression: " + dateRangeExpr, 0);
+        }
         return parseDateRange(dateRangeExpr, null);
     }
     public static List<Date> parseDateRange(String dateRangeExpr, Date defaultDate) throws ParseException {

--- a/test/amberdb/util/DateParserTest.java
+++ b/test/amberdb/util/DateParserTest.java
@@ -7,12 +7,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.regex.MatchResult;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class DateParserTest {
@@ -78,6 +74,12 @@ public class DateParserTest {
         expectedToDate.add(dateFmt.parse("09/03/1732"));  // to chk
         expectedToDate.add(dateFmt.parse("12/09/1984"));
         expectedToDate.add(dateFmt.parse("31/05/1993"));
+    }
+    
+    @Test(expected = ParseException.class)
+    public void testInvalidDateRange() throws ParseException {
+        String str = "invalid date range str";
+        List<Date> dateRange = DateParser.parseDateRange(str);
     }
     
     @Test


### PR DESCRIPTION
This request provides fix for problem discovered during testing of parsing a text string that does not contain any number as date range (e.g. "as time goes by...") for ead ingest.