### PR TITLE
updated file size method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.1.296-SNAPSHOT 
+###Latest AmberDb snapshot version : 1.1.297-SNAPSHOT 
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.296-SNAPSHOT</version>
+  <version>1.1.297-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/model/File.java
+++ b/src/amberdb/model/File.java
@@ -71,7 +71,7 @@ public interface File extends Node {
     @Property("fileSize")
     public void setFileSize(long fileSize);
 
-    @Property("fileSize")
+    @JavaHandler
     public long getFileSize();
     
     @Property("compression")
@@ -165,7 +165,7 @@ public interface File extends Node {
     public Copy getCopy();
 
     @JavaHandler
-    public long getSize() throws NoSuchBlobException, IOException;
+    public long getSize();
 
     @JavaHandler
     public SeekableByteChannel openChannel() throws IOException;
@@ -199,6 +199,12 @@ public interface File extends Node {
             return getBlobStore().get(getBlobId());
         }
         
+        @Override
+        public long getFileSize() {
+            Long fileSize = this.asVertex().getProperty("fileSize");
+            return (fileSize == null)? 0L : fileSize;  
+        }
+        
         /**
          * Return the size of the blob. If an exception occurs try and 
          * return the fileSize property. If that fails, return 0L.
@@ -209,11 +215,7 @@ public interface File extends Node {
                 return getBlob().size();
             } catch (NoSuchBlobException | IOException e) {
                 // As a last resort see if the file has a size property to return
-                try {
-                    return getFileSize();
-                } catch (Exception ex) {
-                    return 0L;
-                }
+                return getFileSize();
             }
         }
 

--- a/test/amberdb/model/FileTest.java
+++ b/test/amberdb/model/FileTest.java
@@ -1,0 +1,36 @@
+package amberdb.model;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import amberdb.AmberSession;
+
+public class FileTest {
+    private AmberSession amberDb;
+    
+    @Before
+    public void startup() {
+        amberDb = new AmberSession();           
+    }
+    
+    @After
+    public void teardown() throws IOException {
+        if (amberDb != null) {
+            amberDb.close();
+        }       
+    }
+    
+    @Test
+    public void shouldReturn0InAbsenceOfFileSize() {
+        Work work = amberDb.addWork();
+        Copy copy = work.addCopy();
+        File file = copy.addFile();
+        assertEquals(0L, file.getFileSize());
+        assertEquals(0L, file.getSize());
+    }
+}


### PR DESCRIPTION
As file size is returned as a primitive long, and referenced widely already, this request provides a default long value 0L as return value to simplify calling code checking for NPE.

@ninhnguyen could you please review these change?  Thanks. 