### PR TITLE
add check condition for potential invalid date with number or hyphen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.1.298-SNAPSHOT 
+###Latest AmberDb snapshot version : 1.1.299-SNAPSHOT 
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.298-SNAPSHOT</version>
+  <version>1.1.299-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/util/DateParser.java
+++ b/src/amberdb/util/DateParser.java
@@ -74,7 +74,11 @@ public class DateParser {
         if (!StringUtils.isEmpty(dateRangeExpr) && !dateRangeExpr.matches(numberInStrExpr)) {
             throw new ParseException("Invalid date expression: " + dateRangeExpr, 0);
         }
-        return parseDateRange(dateRangeExpr, null);
+        try {
+            return parseDateRange(dateRangeExpr, null);
+        } catch (ParseException e) {
+            throw new ParseException("Invalid date expression: " + dateRangeExpr, 0);
+        }
     }
     public static List<Date> parseDateRange(String dateRangeExpr, Date defaultDate) throws ParseException {
         if (dateRangeExpr == null || dateRangeExpr.trim().isEmpty()) return null;
@@ -224,6 +228,8 @@ public class DateParser {
             } else if ((month = MONTH.getMonthOfYear(dateExpr)) != null) {
                 cal.set(Calendar.DAY_OF_MONTH, 0);
                 cal.set(Calendar.MONTH, MONTH.getMonthOfYear(dateExpr), month - 1);
+            } else {
+                throw new ParseException("Invalid date expression: " + dateExpr, 0);
             }
             return cal.getTime();
         }

--- a/test/amberdb/util/DateParserTest.java
+++ b/test/amberdb/util/DateParserTest.java
@@ -77,8 +77,20 @@ public class DateParserTest {
     }
     
     @Test(expected = ParseException.class)
-    public void testInvalidDateRange() throws ParseException {
+    public void testInvalidDateRangeWithoutNumber() throws ParseException {
         String str = "invalid date range str";
+        List<Date> dateRange = DateParser.parseDateRange(str);
+    }
+    
+    @Test(expected = ParseException.class)
+    public void testInvalidDateRangeWithNumber() throws ParseException {
+        String str = "19th century";
+        List<Date> dateRange = DateParser.parseDateRange(str);
+    }
+    
+    @Test(expected = ParseException.class)
+    public void testInvalidDateRangeWithAHyphen() throws ParseException {
+        String str = "19th-century";
         List<Date> dateRange = DateParser.parseDateRange(str);
     }
     


### PR DESCRIPTION
This request further improve on the date parser's ability to recognize invalid date expression strings during date range extraction.  It now filters out strings containing only 1-2 digits number that is neither year, or month of any particular year or date in any particular month of any particular year.

