### PR TITLE
Remove JSON generation as it's not required by business or us.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.1.302-SNAPSHOT
+###Latest AmberDb snapshot version : 1.1.303-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.1.302-SNAPSHOT</version>
+  <version>1.1.303-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/model/builder/CollectionBuilder.java
+++ b/src/amberdb/model/builder/CollectionBuilder.java
@@ -1,80 +1,36 @@
 package amberdb.model.builder;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
+import amberdb.PIUtil;
+import amberdb.enums.AccessCondition;
+import amberdb.enums.CopyRole;
+import amberdb.enums.DigitalStatus;
+import amberdb.model.*;
+import amberdb.util.DateParser;
+import doss.core.Writables;
 import nu.xom.Node;
 import nu.xom.Nodes;
 import nu.xom.ParsingException;
 import nu.xom.ValidityException;
-
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import doss.core.Writables;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
-import amberdb.PIUtil;
-import amberdb.enums.AccessCondition;
-import amberdb.enums.CopyRole;
-import amberdb.enums.DigitalStatus;
-import amberdb.model.Copy;
-import amberdb.model.EADEntity;
-import amberdb.model.EADFeature;
-import amberdb.model.EADWork;
-import amberdb.model.File;
-import amberdb.model.Work;
-import amberdb.util.DateParser;
-
-import static amberdb.model.builder.XmlDocumentParser.CFG_COLLECTION_ELEMENT;
-import static amberdb.model.builder.XmlDocumentParser.CFG_SUB_ELEMENTS;
-import static amberdb.model.builder.XmlDocumentParser.CFG_FEATURE_ELEMENTS;
-import static amberdb.model.builder.XmlDocumentParser.CFG_ENTITY_ELEMENTS;
-import static amberdb.model.builder.XmlDocumentParser.CFG_BASE;
-import static amberdb.model.builder.XmlDocumentParser.CFG_REPEATABLE_ELEMENTS;
+import static amberdb.model.builder.XmlDocumentParser.*;
 
 public class CollectionBuilder {
     static final Logger log = LoggerFactory.getLogger(CollectionBuilder.class);
     static final ObjectMapper mapper = new ObjectMapper();
-    
-    /**
-     * createCollection in absence of collection configuration and document parser input parameters, 
-     * resolves to default collection JSON configuration and the default EAD parser in order to 
-     * create the collection work structure under the top level collection work.
-     * 
-     * @param collectionWork: the top-level work of a collection with a FINDING_AID_COPY attached.
-     * @param validateEADXML: a flag to indicate whether to validate EAD in XML format to ensure 
-     *                        it's well formed. 
-     * @throws EADValidationException
-     * @throws IOException 
-     * @throws ParsingException 
-     * @throws ValidityException 
-     */
-    public static void createCollection(Work collectionWork, boolean validateEADXML) throws EADValidationException, ValidityException, ParsingException, IOException {
-        JsonNode collectCfg = getDefaultCollectionCfg();
-        String validateFlag = (validateEADXML)?"yes":"no";
-        ((ObjectNode) collectCfg.get(XmlDocumentParser.CFG_COLLECTION_ELEMENT)).put("validateXML", validateFlag);
-        createCollection(collectionWork, collectCfg, getDefaultXmlDocumentParser());
-    }
     
     /**
      * getDefaultCollectionCfg returns the default configuration for creating a hierarchy of works under
@@ -92,7 +48,7 @@ public class CollectionBuilder {
      * getDefaultXmlDocumentParser returns the EADParser as the default xml document parser
      * for the CollectionBuilder.
      */
-    public static XmlDocumentParser getDefaultXmlDocumentParser() {
+    protected static XmlDocumentParser getDefaultXmlDocumentParser() {
         return new EADParser();
     }
     
@@ -144,8 +100,8 @@ public class CollectionBuilder {
      * reloadEADPreChecks checks each EADwork within the collectionWork and returns a list of EADwork object id
      * if these EADwork does not exist in the new EAD file for reload.  
      *   
-     * @param collection - the top level work of a collection with the new updated EAD finding aid attached as
-     *                     the FINDING_AID_COPY, and the FINDING_AID_VIEW_COPY containing json not yet containing 
+     * @param collectionWork - the top level work of a collection with the new updated EAD finding aid attached as
+     *                     the FINDING_AID_COPY not yet containing
      *                     updates from the new updated FINDING_AID_COPY.
      * @return list of nla object ids of the EADworks requiring EAD update review.
      * @throws IOException 
@@ -206,21 +162,19 @@ public class CollectionBuilder {
      * @throws IOException
      */
     protected static Map<String, String> componentWorksMap(Work collectionWork) throws IOException {
-        JsonNode content = getFindingAIDJsonDocument(collectionWork).getContent();
+        List<Work> works = getObjIdsInTree(collectionWork);
         Map<String, String> uuidToPIMap = new HashMap<>();
 
-        if (content != null && content.getFieldNames() != null) {
-            Iterator<String> fieldNames = content.getFieldNames();
-            while (fieldNames.hasNext()) {
-                String objId = fieldNames.next();
-                if (content.get(objId).get("localSystemNumber") != null) {
-                    String uuid = content.get(objId).get("localSystemNumber").getTextValue();
-                    uuidToPIMap.put(uuid, objId);
-                } 
+        for (Work work : works) {
+            if (work.getLocalSystemNumber() != null) {
+                String uuid = work.getLocalSystemNumber();
+                uuidToPIMap.put(uuid, work.getObjId());
             }
         }
         return uuidToPIMap;
     }
+
+
     
     /**
      * digitisedItemList provides a list of objId of each EAD works within collectionWork (including the collectionWork)
@@ -237,40 +191,50 @@ public class CollectionBuilder {
     protected static Set<String> digitisedItemList(Work collectionWork) throws IOException {
         // Get a list of EAD component works in the current collection work
         // structure which has digital objects attached
-        JsonNode content = getFindingAIDJsonDocument(collectionWork).getContent();
-        Set<String> objIdList = Collections.synchronizedSet(new HashSet<String>());
+        List<Work> works = getObjIdsInTree(collectionWork);
+        Set<String> objIdList = new HashSet<String>();
+        for (Work work : works) {
+            String objId = work.getObjId();
+            // find the component work
+            if (!objId.equals(collectionWork.getObjId())) {
+                EADWork component = work.asEADWork();
 
-        if (content != null && content.getFieldNames() != null) {
-            Iterator<String> fieldNames = content.getFieldNames();
-            while (fieldNames.hasNext()) {
-                String objId = fieldNames.next();
-                // find the component work
-                if (!objId.equals(collectionWork.getObjId())) {
-                    EADWork component = collectionWork.asEADWork().getEADWork(PIUtil.parse(objId));
-
-                    // add entry to digitalObjectsMap if the component has any
-                    // copies attached
-                    if (component != null
-                            && (component.getCopies() != null && component.getCopies().iterator().hasNext())) {
-                        objIdList.add(objId); 
-                    }
+                // add entry to digitalObjectsMap if the component has any
+                // copies attached
+                if (component != null
+                        && (component.getCopies() != null && component.getCopies().iterator().hasNext())) {
+                    objIdList.add(objId);
                 }
             }
         }
         return objIdList;
     }
-    
-    protected static Document getFindingAIDJsonDocument(Work collectionWork) throws IOException {
-        Copy eadJsonCopy = collectionWork.getCopy(CopyRole.FINDING_AID_VIEW_COPY);
-        if (eadJsonCopy == null || eadJsonCopy.getFile() == null) {
-            return generateJson(collectionWork);
+
+    public static List<Work> getWorksRequiringReview(Work collectionWork) {
+        List<Work> works = getObjIdsInTree(collectionWork);
+        List<Work> worksForReview = new ArrayList<>();
+        for (Work work : works) {
+            EADWork eadWork = work.asEADWork();
+            if ("Y".equals(eadWork.getEADUpdateReviewRequired())) {
+                worksForReview.add(work);
+            }
         }
-        File eadJsonFile = eadJsonCopy.getFile();
-        JsonNode eadJson = mapper.readTree(eadJsonFile.openStream());
-        Document doc = new Document(eadJson.get("structure"), eadJson.get("content"));
-        return doc;
+        return worksForReview;
     }
 
+    private static List<Work> getObjIdsInTree(Work collectionWork) {
+        List<Work> works = new ArrayList<>();
+        getObjsInTreeR(collectionWork, works);
+        return works;
+    }
+
+    private static void getObjsInTreeR(Work collectionWork, List<Work> populateList) {
+        populateList.add(collectionWork);
+        for (Work child : collectionWork.getChildren()) {
+            getObjsInTreeR(child, populateList);
+        }
+    }
+    
     /**
      * reloadCollection parses the updated EAD file attached to the top-level
      * collection work with the input field mapping from collectionCfg, and
@@ -392,48 +356,6 @@ public class CollectionBuilder {
         return eadFile;
     }
     
-    /**
-     * generateJson generates a document in json format consist the mapping of the structure and
-     * the content for top level collection metadata and its components and sub-components:
-     *  - the structure is a json tree with top node at collection level and branches and leaves
-     *    of components and sub-components.
-     *  - the content is a json array of items (including the collection and its components and
-     *    sub-components) in a flat structure, and each item within the array contains the required
-     *    metadata for the delivery.
-     *
-     * If the storeCopy flag is set to true, the generated Json document will be stored as a finding aid view copy
-     * of the top level collection work.
-     *
-     * Store Copy rule: if the collectionWork has already an existing finding aid view copy, and the existing
-     *                  copy will be deleted and the newly generated view copy will be stored.
-     *
-     * @param collectionWork - the top level work of a collection with a FINDING_AID_COPY attached.
-     * @return Document      - the newly generated document containing structure and content json
-     *                         nodes.
-     * @throws IOException
-     */
-    public static Document generateJson(Work collectionWork) throws IOException {
-        if (collectionWork == null) {
-            String errMsg = "Failed to generate collection json as the input collection work is null.";
-            log.error(errMsg);
-            throw new IllegalArgumentException(errMsg);
-        }
-
-        ObjectNode structure = mapper.createObjectNode();
-        ObjectNode content = mapper.createObjectNode();
-        ObjectNode statusReport = mapper.createObjectNode();
-
-        // create the document from the work.
-        traverseCollection(collectionWork, structure, content, statusReport);
-        Document doc = new Document(structure, content);
-
-        // set status report if there's any ead work requiring review
-        if (statusReport.size() > 0) doc.setStatusReport(statusReport);
-
-        // store the document as a copy to collectionWork.
-        return doc;
-    }
-
     /**
      * filterEAD: filter the input EAD document so that only elements required for delivery are retained in the EAD document.
      * 
@@ -930,154 +852,5 @@ public class CollectionBuilder {
         ComponentBuilder.mapWorkMD(workInCollection, uuid, fieldsMap);
         return workInCollection;
     }
-    
-    protected static void traverseCollection (Work work, JsonNode structure, JsonNode content, JsonNode statusReport) {
-        JsonNode workProperties = mapWorkProperties(work);
-        ObjectMapper om = new ObjectMapper();
 
-        String uuid = "";
-        if (workProperties.get("localSystemNumber") != null && !workProperties.get("localSystemNumber").getTextValue().isEmpty()) {
-            uuid = workProperties.get("localSystemNumber").getTextValue();
-        }
-        if (uuid.isEmpty()) {
-            ((ObjectNode) structure).put(work.getObjId(), work.getCollection());
-        } else {   
-            ((ObjectNode) structure).put(work.getObjId(), uuid);
-        }
-        ((ObjectNode) content).put(work.getObjId(), workProperties);
-        
-        String eadUpdateReviewRequired= work.asEADWork().getEADUpdateReviewRequired();
-        if (eadUpdateReviewRequired != null && eadUpdateReviewRequired.equals("Y")) {
-            ArrayNode eadUpdateReviewList;
-            if (statusReport.get("eadUpdateReviewRequired") == null) {
-                eadUpdateReviewList = om.createArrayNode();
-                ((ObjectNode) statusReport).put("eadUpdateReviewRequired", eadUpdateReviewList);
-            } else {
-                eadUpdateReviewList = (ArrayNode) statusReport.get("eadUpdateReviewRequired");
-            }
-            eadUpdateReviewList.add(work.getObjId());
-        }
-        String dateRangeInAS = work.asEADWork().getDateRangInAS();
-        if (dateRangeInAS != null && !dateRangeInAS.isEmpty()) {
-            JsonNode dateRangeList;
-            if (statusReport.get("dateRangeReviewRequired") == null) {
-                dateRangeList = om.createObjectNode();
-                ((ObjectNode) statusReport).put("dateRangeReviewRequired", dateRangeList);
-            } else {
-                dateRangeList = (JsonNode) statusReport.get("dateRangeReviewRequired");
-            }
-            if (dateRangeList.get(dateRangeInAS) == null) {
-                SimpleDateFormat fmt = new SimpleDateFormat("dd/MM/yyyy");
-                ObjectNode dateRange = om.createObjectNode();
-                Date startDate = work.asEADWork().getStartDate();
-                dateRange.put("startDate", (startDate == null)?"":fmt.format(startDate));
-                Date endDate = work.asEADWork().getEndDate();
-                dateRange.put("endDate", (endDate == null)?"":fmt.format(endDate));
-                ((ObjectNode) dateRangeList).put(dateRangeInAS, dateRange);  
-            } 
-        }
-            
-        traverseCollection(work.getChildren(), structure, content, statusReport);
-    }
-    
-    protected static void traverseCollection (Iterable<Work> works, JsonNode structure, JsonNode content, JsonNode statusReport) {
-        if (works == null || !works.iterator().hasNext()) return;
-        ArrayNode arry = mapper.createArrayNode();
-        ((ObjectNode) structure).put(XmlDocumentParser.CFG_SUB_ELEMENTS, arry);
-        for (Work work : works) {
-            JsonNode item = mapper.createObjectNode();
-            arry.add(item);
-            traverseCollection(work, item, content, statusReport);
-        }
-    }
-    
-    private static JsonNode mapWorkProperties(Work work) {
-        JsonNode workProperties = mapper.createObjectNode();
-        String[] fields = { "repository", "extent", "collectionNumber", "dcmWorkPid", "arrangement", "access",
-                "copyingPublising", "preferredCitation", "relatedMaterial", "provenance", "creator", "title",
-                "digitalStatus", "subType", "subUnitType", "form", "bibLevel", "collection", "bibliography",
-                "adminInfo", "recordSource", "localSystemNumber", "rdsAcknowledgementType",
-                "rdsAcknowledgementReceiver", "eadUpdateReviewRequired", "accessConditions", "subUnitType",
-                "subUnitNo", "scopeContent", "dateRangeInAS", "folder" };
-        List<String> background = null;
-        // map general work properties
-        for (String field : fields) {
-            if (work.asVertex().getProperty(field) != null) {
-                ((ObjectNode) workProperties).put(field, work.asVertex().getProperty(field).toString());
-            }
-        }
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy:MM:dd");
-        String startDate = null;
-        if (work.getStartDate() != null) {
-            startDate = dateFmt.format(work.getStartDate());
-        } 
-        ((ObjectNode) workProperties).put("startDate", startDate);
-        String endDate = null;
-        if (work.getEndDate() != null) {
-            endDate = dateFmt.format(work.getEndDate());
-        }
-        ((ObjectNode) workProperties).put("endDate", endDate);
-        
-        // map background
-        try {
-            List<String> bibliography = work.asEADWork().getBibliography();
-            if (bibliography != null && !bibliography.isEmpty()) {
-                background = bibliography;
-            } else {
-                String adminInfo = work.asEADWork().getAdminInfo();
-                if (adminInfo != null && !adminInfo.isEmpty()) {
-                    background = new ArrayList<>();
-                    background.add(adminInfo);
-                }
-            }
-            if (background != null) {
-                ArrayNode backgroundHist = mapper.createArrayNode();
-                for (String item : background) {
-                    backgroundHist.add(item);
-                }
-                ((ObjectNode) workProperties).put("background", backgroundHist);
-            }
-        } catch (IOException e) {
-            log.error("Failed to retrieve background for collection work " + work.getObjId());
-            throw new EADValidationException("FAILED_EXTRACT_BIBLIOGRAPHY", e, work.getObjId());
-        }
-        
-        ArrayNode features = mapEADFeatures(work);
-        if (features != null) {
-            ((ObjectNode) workProperties).put("containerList", features);
-        }
-        
-        ArrayNode entities = mapEADEntities(work);
-        if (entities != null) {
-            ((ObjectNode) workProperties).put("correspondenceIndex", entities);
-        }
-        return workProperties;
-    }
-    
-    private static ArrayNode mapEADFeatures(Work work) {
-        List<EADFeature> list = work.asEADWork().getEADFeatures();
-        if (list == null) return null;
-        ArrayNode features = mapper.createArrayNode();
-        for (EADFeature e : list) {
-            ObjectNode feature = mapper.createObjectNode();
-            feature.put("featureType", e.getFeatureType());
-            feature.put("fields", e.getJSONFields());
-            feature.put("records", e.getJSONRecords());
-            features.add(feature);
-        }
-        return features;
-    }
-    
-    private static ArrayNode mapEADEntities(Work work) {
-        List<EADEntity> list = work.asEADWork().getEADEntities();
-        if (list == null) return null;
-        ArrayNode entities = mapper.createArrayNode();
-        for (EADEntity e : list) {
-            ObjectNode entity = mapper.createObjectNode();
-            entity.put("entityName", e.getJSONEntityName());
-            entity.put("correspondenceRef", e.getCorrespondencRef());
-            entities.add(entity);
-        }
-        return entities;
-    }
 }

--- a/test/amberdb/model/builder/CollectionBuilderTest.java
+++ b/test/amberdb/model/builder/CollectionBuilderTest.java
@@ -1,42 +1,5 @@
 package amberdb.model.builder;
 
-import static org.junit.Assert.*;
-
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ByteArrayInputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.sql.DataSource;
-import nu.xom.Element;
-import nu.xom.Elements;
-import nu.xom.Node;
-import nu.xom.ParsingException;
-import nu.xom.ValidityException;
-
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import amberdb.AmberDb;
 import amberdb.AmberSession;
 import amberdb.enums.AccessCondition;
@@ -45,6 +8,31 @@ import amberdb.model.Copy;
 import amberdb.model.EADEntity;
 import amberdb.model.EADFeature;
 import amberdb.model.Work;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import nu.xom.*;
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.ObjectNode;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class CollectionBuilderTest {
     static final Logger log = LoggerFactory.getLogger(CollectionBuilderTest.class);
@@ -165,27 +153,6 @@ public class CollectionBuilderTest {
     }
     
     @Test
-    public void testGenerateJson() throws IOException, ValidityException, ParsingException {
-        createCollection();
-        try (AmberSession as = db.begin()) {
-            Work collectionWork = as.findWork(collectionWorkId);
-            boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork);
-            System.out.println("doc: " + doc.toJson());
-            JsonNode content = doc.getContent();
-            Iterator<String> it = content.getFieldNames();
-            assertTrue(it.hasNext());
-            int i = 0;
-            while (it.hasNext()) {
-                it.next();
-                i++;
-            }
-            assertEquals(9, i);
-//            assertEquals(collectionWork.getCopy(CopyRole.FINDING_AID_COPY), collectionWork.getCopy(CopyRole.FINDING_AID_VIEW_COPY).getSourceCopy());
-        }
-    }
-        
-    @Test
     public void testFilterEAD() throws IOException, ValidityException, ParsingException {
         try (AmberSession as = db.begin()) {
            Work collectionWork = as.findWork(collectionWorkId);
@@ -283,7 +250,7 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork);
+//            Document doc = CollectionBuilder.generateJson(collectionWork);
             InputStream in = new FileInputStream(testEADPath.toFile());
             EADParser parser = new EADParser();
             parser.init(collectionWorkId, in, collectCfg);
@@ -301,9 +268,7 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             collectionWork.setCollection("nla.ms");
-            boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork);
-            assertNull(doc.getReport().get("eadUpdateReviewRequired"));
+            assertEquals(CollectionBuilder.getWorksRequiringReview(collectionWork).size(), 0);
             // verify the component of AS id (i.e updedCompASId) has collection work as its parent
             Map<String, String> uuidToPIMap = CollectionBuilder.componentWorksMap(collectionWork);
             Work componentToUpdate = as.findWork(uuidToPIMap.get(updedCompASId));
@@ -321,11 +286,7 @@ public class CollectionBuilderTest {
             //         - add new component works from the updated EAD.
             //         - update existing component works from the updated EAD.
             CollectionBuilder.reloadCollection(collectionWork);
-            doc = CollectionBuilder.generateJson(collectionWork);
-            JsonNode statusReport = doc.getReport();
-            assertNotNull(statusReport);
-            assertNotNull(statusReport.get("eadUpdateReviewRequired"));
-            assertEquals(1, statusReport.get("eadUpdateReviewRequired").size());
+            assertEquals(1, CollectionBuilder.getWorksRequiringReview(collectionWork).size());
             as.commit();
             
             // verify the component of AS id (i.e. updatedCompAsId) is under the first component work 
@@ -345,19 +306,28 @@ public class CollectionBuilderTest {
             Work collectionWork = as.findWork(collectionWorkId);
             List<EADFeature> features = collectionWork.asEADWork().getEADFeatures();
             assertEquals("features extracted", 2, features.size());
-            assertEquals("first feature heading", "General", features.get(0).getFeatureType());
-            assertEquals("second feature heading", "Container List", features.get(1).getFeatureType());
+            ImmutableMap<String, EADFeature> stringEADFeatureImmutableMap =
+                    Maps.uniqueIndex(features, new Function<EADFeature, String>() {
+                        @Override
+                        public String apply(EADFeature eadFeature) {
+                            return eadFeature.getFeatureType();
+                        }
+                    });
+            assertTrue("first feature heading", stringEADFeatureImmutableMap.containsKey("General"));
+            assertTrue("second feature heading", stringEADFeatureImmutableMap.containsKey("Container List"));
             
             // verify extracted general note
-            List<String> generalFields = features.get(0).getFields();
-            List<List<String>> generalRecords = features.get(0).getRecords();
+            EADFeature generalFeature = stringEADFeatureImmutableMap.get("General");
+            EADFeature containerFeature = stringEADFeatureImmutableMap.get("Container List");
+            List<String> generalFields = generalFeature.getFields();
+            List<List<String>> generalRecords = generalFeature.getRecords();
             assertEquals("general notes size", 2, generalRecords.size());
             assertEquals("no. of fields for general notes", 1, generalFields.size());
             assertEquals("no. of records for general notes", 2, generalRecords.size());
             
             // verify extracted container list
-            List<String> containerListFields = features.get(1).getFields();
-            List<List<String>> containerListRecords = features.get(1).getRecords();
+            List<String> containerListFields = containerFeature.getFields();
+            List<List<String>> containerListRecords = containerFeature.getRecords();
             assertEquals("container list size", 176, containerListRecords.size());
             assertEquals("no. of fields for container record", 4, containerListFields.size());
             assertEquals("first container record: Series", "1", containerListRecords.get(0).get(0));

--- a/test/amberdb/model/builder/CollectionBuilderTest.java
+++ b/test/amberdb/model/builder/CollectionBuilderTest.java
@@ -170,7 +170,7 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork, storeCopy);
+            Document doc = CollectionBuilder.generateJson(collectionWork);
             System.out.println("doc: " + doc.toJson());
             JsonNode content = doc.getContent();
             Iterator<String> it = content.getFieldNames();
@@ -181,7 +181,7 @@ public class CollectionBuilderTest {
                 i++;
             }
             assertEquals(9, i);
-            assertEquals(collectionWork.getCopy(CopyRole.FINDING_AID_COPY), collectionWork.getCopy(CopyRole.FINDING_AID_VIEW_COPY).getSourceCopy());
+//            assertEquals(collectionWork.getCopy(CopyRole.FINDING_AID_COPY), collectionWork.getCopy(CopyRole.FINDING_AID_VIEW_COPY).getSourceCopy());
         }
     }
         
@@ -283,7 +283,7 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork, storeCopy);
+            Document doc = CollectionBuilder.generateJson(collectionWork);
             InputStream in = new FileInputStream(testEADPath.toFile());
             EADParser parser = new EADParser();
             parser.init(collectionWorkId, in, collectCfg);
@@ -302,7 +302,7 @@ public class CollectionBuilderTest {
             Work collectionWork = as.findWork(collectionWorkId);
             collectionWork.setCollection("nla.ms");
             boolean storeCopy = true;
-            Document doc = CollectionBuilder.generateJson(collectionWork, storeCopy);
+            Document doc = CollectionBuilder.generateJson(collectionWork);
             assertNull(doc.getReport().get("eadUpdateReviewRequired"));
             // verify the component of AS id (i.e updedCompASId) has collection work as its parent
             Map<String, String> uuidToPIMap = CollectionBuilder.componentWorksMap(collectionWork);
@@ -321,7 +321,7 @@ public class CollectionBuilderTest {
             //         - add new component works from the updated EAD.
             //         - update existing component works from the updated EAD.
             CollectionBuilder.reloadCollection(collectionWork);
-            doc = CollectionBuilder.generateJson(collectionWork, storeCopy);
+            doc = CollectionBuilder.generateJson(collectionWork);
             JsonNode statusReport = doc.getReport();
             assertNotNull(statusReport);
             assertNotNull(statusReport.get("eadUpdateReviewRequired"));
@@ -388,7 +388,6 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             boolean storeCopy = true;
-            CollectionBuilder.generateJson(collectionWork, storeCopy);
             Map<String, String> componentWorksMap = CollectionBuilder.componentWorksMap(collectionWork);
             assertTrue(!componentWorksMap.isEmpty());
             assertEquals(componentWorksMap.size(), 8);
@@ -401,7 +400,6 @@ public class CollectionBuilderTest {
         try (AmberSession as = db.begin()) {
             Work collectionWork = as.findWork(collectionWorkId);
             boolean storeCopy = true;
-            CollectionBuilder.generateJson(collectionWork, storeCopy);
             Set<String> currentDOs = CollectionBuilder.digitisedItemList(collectionWork);
             assertTrue(currentDOs.isEmpty());
         }


### PR DESCRIPTION
Note that I considered making CollectionBuilder a non-static class. Then there would be the potential to lazy-load the collection works into a field, which has potential time savings if there are multiple calls to getObjsInTree. Thoughts?

@scoen @shuangzhou @terenceingram @bsingh-nla  Please look