### PR TITLE
add empty list guard to json serialisation

### DIFF
--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -1588,7 +1588,7 @@ public interface Work extends Node {
         }
 
         protected String serialiseToJSON(Collection<String> list) throws JsonParseException, JsonMappingException, IOException {
-            if (list == null) return null;    
+            if (list == null || list.isEmpty()) return null;    
             return mapper.writeValueAsString(list);
         }
 


### PR DESCRIPTION
@shuangzhou 
After seeing the enhancement you put in earlier to ensure uniqueness for Subjects during JSON serializing, i've also added a guard to the serialiseToJSON method to prevent empty lists being saved. Would you take a look ?