### PR TITLE
add copyRole null check

### DIFF
--- a/src/amberdb/enums/CopyRole.java
+++ b/src/amberdb/enums/CopyRole.java
@@ -147,7 +147,10 @@ public enum CopyRole {
     public static Collection<Copy> reorderCopyList(Iterable<Copy> copies) {
         TreeMap<Integer, Copy> rearranged = new TreeMap<>();
         for (Copy copy : copies) {
-            rearranged.put(CopyRole.fromString(copy.getCopyRole()).ord(), copy);
+            CopyRole copyRole = CopyRole.fromString(copy.getCopyRole());
+            if (copyRole != null){
+                rearranged.put(copyRole.ord(), copy);    
+            }
         }
         return rearranged.values();
     }


### PR DESCRIPTION
@bsingh-nla 
Just make the code more robust --  When a work has a new copy role, snowy breaks before the code is merged. 