### PR TITLE
query to retrieve a Work's Sections (articles and chapters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.2.17-SNAPSHOT
+###Latest AmberDb snapshot version : 1.2.18-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.2.17-SNAPSHOT</version>
+  <version>1.2.18-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/query/WorkChildrenQuery.java
+++ b/src/amberdb/query/WorkChildrenQuery.java
@@ -5,6 +5,7 @@ import amberdb.enums.CopyRole;
 import amberdb.graph.AmberProperty;
 import amberdb.graph.AmberQueryBase;
 import amberdb.graph.DataType;
+import amberdb.model.Section;
 import amberdb.model.Work;
 
 import java.util.ArrayList;
@@ -164,6 +165,46 @@ public class WorkChildrenQuery extends AmberQueryBase {
         return children;
     }
     
+    public List<Section> getSections(Long workId) {
+
+        StringBuilder s = new StringBuilder();
+        List<Section> sections =  new ArrayList<>();
+        String tDrop = graph.getTempTableDrop();
+        String tEngine = graph.getTempTableEngine();
+
+        s.append(
+            "DROP " + tDrop + " TABLE IF EXISTS v1; \n" +
+            "CREATE TEMPORARY TABLE v1 (id BIGINT, obj_type CHAR(1), ord BIGINT)" + tEngine + "; \n");
+
+        // add children Sections
+        s.append(
+            "INSERT INTO v1 (id, obj_type, ord) \n" +
+            "SELECT DISTINCT v.id, 'W', e.edge_order \n" +
+            "FROM vertex v, edge e, property p \n" +
+            "WHERE v.txn_end = 0 AND e.txn_end = 0 AND p.txn_end = 0 \n" +
+            " AND e.v_in = "+workId+" \n" +
+            " AND e.v_out = v.id \n" +
+            " AND e.label = 'isPartOf' \n" +
+            " AND p.id = v.id \n" +
+            " AND p.name = 'type' \n" +
+            " AND p.value = '" + Hex.encodeHexString(AmberProperty.encode("Section")) + "'\n" +
+            " ORDER BY e.edge_order; \n");
+
+        List<Vertex> vertices = null;
+        try (Handle h = graph.dbi().open()) {
+            h.begin();
+            h.createStatement(s.toString()).execute();
+            h.commit();
+
+            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "v1", "id");
+            vertices = getVertices(h, graph, propMaps, "v1", "id", "ord");
+
+            for (Vertex v : vertices) {
+                sections.add(sess.getGraph().frame(v, Section.class));
+            }
+        }
+        return sections;
+    }
     
     public Integer getTotalChildCount(Long workId) {
         Integer numChildren = new Integer(0);

--- a/test/amberdb/query/WorkChildrenQueryTest.java
+++ b/test/amberdb/query/WorkChildrenQueryTest.java
@@ -88,6 +88,11 @@ public class WorkChildrenQueryTest {
             assertNotNull(f);
         }
         sess.setLocalMode(false);
+
+        List<Section> sections = wcq.getSections(parent.getId());
+        sess.setLocalMode(true);
+        assertEquals(sections.size(), 7);
+        sess.setLocalMode(false);
     }        
     
 


### PR DESCRIPTION
Need this query to make Banjo show Work page more efficient - currently it queries all children twice to get the articles and chapters for display. This takes a long time for Works with many children. I probably need to refactor getting all of a work at some point, but in the meantime this should do the trick.