### PR TITLE
ms1105: add SiblingEdtions

### DIFF
--- a/src/amber/interactiveindex/InteractiveIndexCopy.java
+++ b/src/amber/interactiveindex/InteractiveIndexCopy.java
@@ -1,5 +1,6 @@
 package amber.interactiveindex;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
@@ -7,6 +8,7 @@ import java.util.List;
 
 public class InteractiveIndexCopy {
     private String html;
+    private List<SiblingEditions> siblingEditionsList = new ArrayList<>();
     private List<InteractiveArea> areas = new ArrayList<>();
 
     public InteractiveIndexCopy(String html) {
@@ -41,10 +43,33 @@ public class InteractiveIndexCopy {
         areas.clear();
     }
 
+    public List<SiblingEditions> getSiblingEditionsList() {
+        return siblingEditionsList;
+    }
+
+    public void setSiblingEditionsList(List<SiblingEditions> siblingEditionsList) {
+        this.siblingEditionsList = siblingEditionsList;
+    }
+
     public InteractiveArea getInteractiveArea(String objectId){
         for (InteractiveArea interactiveArea : areas){
             if (StringUtils.equalsIgnoreCase(interactiveArea.getObjectId(), objectId)){
                 return interactiveArea;
+            }
+        }
+        return null;
+    }
+
+    public void addSiblingEdition(List<String> objIdList) {
+        if (CollectionUtils.isNotEmpty(objIdList) && objIdList.size() > 1){
+            siblingEditionsList.add(new SiblingEditions(objIdList));    
+        }
+    }
+    
+    public List<String> getSiblingEditionObjectIds(String objId){
+        for (SiblingEditions siblingEditions : siblingEditionsList){
+            if (siblingEditions.contains(objId)){
+                return siblingEditions.getAllSiblingEditionObjectIdsBut(objId);
             }
         }
         return null;

--- a/src/amber/interactiveindex/SiblingEditions.java
+++ b/src/amber/interactiveindex/SiblingEditions.java
@@ -1,0 +1,46 @@
+package amber.interactiveindex;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
+
+/**
+ * Represent a map grid with multiple PIs
+ */
+public class SiblingEditions {
+    private List<String> objectIds = new ArrayList<>();
+
+    public SiblingEditions() {
+    }
+    
+    public SiblingEditions(List<String> objIdList) {
+        objectIds.addAll(objIdList);
+    }
+
+    public List<String> getObjectIds() {
+        return objectIds;
+    }
+
+    public void setObjectIds(List<String> objectIds) {
+        this.objectIds = objectIds;
+    }
+
+    public boolean contains(String objId) {
+        return objectIds.contains(objId);
+    }
+
+    /**
+     * Return all object Ids in the objectIds list which is not equal to the specified objId
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> getAllSiblingEditionObjectIdsBut(final String objId) {
+        return (List<String>)CollectionUtils.selectRejected(objectIds, new Predicate() {
+            @Override
+            public boolean evaluate(Object object) {
+                return object.equals(objId);
+            }
+        });
+    }
+}


### PR DESCRIPTION
@terenceingram 
added the new class and field to handle the 'sibling' editions (one map grid has multiple PIs)
I think the info is better extracted and saved into 'interactive index' copy file, rather than re-parse the html at dl-repo service.
So now the json file looks like this
{
"html":"< map name=\"mapname\"> < area >  .. </area > < /map >",
"siblingEditionsList":[{"objectIds":["nla.obj-19192240","nla.obj-19192350"]}],
"areas":[{"objectId":"nla.obj-19195544","neighbours":[{"direction":"E","objectId":"nla.obj-19194664"},
}