### PR TITLE
ms1138: get all sibling edtion object ids including itself

### DIFF
--- a/src/amber/interactiveindex/InteractiveIndexCopy.java
+++ b/src/amber/interactiveindex/InteractiveIndexCopy.java
@@ -69,7 +69,7 @@ public class InteractiveIndexCopy {
     public List<String> getSiblingEditionObjectIds(String objId){
         for (SiblingEditions siblingEditions : siblingEditionsList){
             if (siblingEditions.contains(objId)){
-                return siblingEditions.getAllSiblingEditionObjectIdsBut(objId);
+                return siblingEditions.getObjectIds();
             }
         }
         return null;

--- a/src/amber/interactiveindex/SiblingEditions.java
+++ b/src/amber/interactiveindex/SiblingEditions.java
@@ -30,17 +30,4 @@ public class SiblingEditions {
     public boolean contains(String objId) {
         return objectIds.contains(objId);
     }
-
-    /**
-     * Return all object Ids in the objectIds list which is not equal to the specified objId
-     */
-    @SuppressWarnings("unchecked")
-    public List<String> getAllSiblingEditionObjectIdsBut(final String objId) {
-        return (List<String>)CollectionUtils.selectRejected(objectIds, new Predicate() {
-            @Override
-            public boolean evaluate(Object object) {
-                return object.equals(objId);
-            }
-        });
-    }
 }


### PR DESCRIPTION
@terenceingram @scoen 
- need to display all the sibling editions (including itself) in the dropdown