### PR TITLE
Sc wrap retry and delivered on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB                       
 =======
 
-###Latest AmberDb snapshot version : 1.2.20-SNAPSHOT
+###Latest AmberDb snapshot version : 1.5.2-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.5.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/AmberSession.java
+++ b/src/amberdb/AmberSession.java
@@ -865,12 +865,13 @@ public class AmberSession implements AutoCloseable {
 
             // get all the copies, files etc
             q.continueWithCheck(null,
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"represents"}, Direction.IN),
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"isCopyOf"}, Direction.IN),
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"isFileOf"}, Direction.IN),
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"descriptionOf"}, Direction.IN),
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"tags"}, Direction.IN),
-                    q.new QueryClause(BRANCH_FROM_ALL, new String[]{"acknowledge"}, Direction.OUT)
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"deliveredOn"}, Direction.OUT),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"represents"}, Direction.IN),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"isCopyOf"}, Direction.IN),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"isFileOf"}, Direction.IN),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"descriptionOf"}, Direction.IN),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"tags"}, Direction.IN),
+                    q.new QueryClause(BRANCH_FROM_ALL, new String[] {"acknowledge"}, Direction.OUT)
                     );
             components = q.getResults(true);
         }

--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -1410,11 +1410,12 @@ public interface Work extends Node {
                 query.branch(BRANCH_FROM_ALL, new String[] {"represents"}, Direction.IN);
             }
 
-            query.branch(BRANCH_FROM_ALL, new String[] {"isCopyOf"}, Direction.IN)
+            query.branch(BRANCH_FROM_ALL, new String[] {"deliveredOn"}, Direction.OUT)
+                 .branch(BRANCH_FROM_ALL, new String[] {"isCopyOf"}, Direction.IN)
                  .branch(BRANCH_FROM_PREVIOUS, new String[] {"isFileOf"}, Direction.IN)
                  .branch(BRANCH_FROM_ALL, new String[] {"descriptionOf"}, Direction.IN)
                  .branch(BRANCH_FROM_ALL, new String[] {"tags"}, Direction.IN)
-                 .branch(BRANCH_FROM_ALL, new String[]{"acknowledge"}, Direction.OUT)
+                 .branch(BRANCH_FROM_ALL, new String[] {"acknowledge"}, Direction.OUT)
                  .execute(true);
         }
 


### PR DESCRIPTION
2 fixes in this pull request (see first 2 commits)
first commit fixes bad wrapping of commit retries that was causing duplicate vertices in amberdb
second adds the 'deliveredOn' relationship to the loading of works into memory
@yetti 
Yetrina, would you take a look at the second one at least ?