### PR TITLE
Ms1134: sort on field children reorder

### DIFF
--- a/src/amberdb/query/WorkChildrenQuery.java
+++ b/src/amberdb/query/WorkChildrenQuery.java
@@ -61,7 +61,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
     }
 
     public List<Work> getChildRange(Long workId, int start, int num){
-        return getChildren(getAddChildrenWokSql(workId, start, num));
+        return getChildren(getAddChildrenWorkSql(workId, start, num));
     }
     
     public List<Work> getChildRangeSortBy(Long workId, int start, int num, final SortItem sortItem){
@@ -69,7 +69,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
             return getChildRange(workId, start, num);
         }
         List<Work> works = getChildren(getAddChildrenWorkSortBySql(workId, start, num, sortItem.fieldName(), sortItem.desc()));
-        Collections.sort(works, sortItem.compartor());
+        Collections.sort(works, sortItem.comparator());
         return works;
     }
     
@@ -166,7 +166,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
         return children;
     }
 
-    private String getAddChildrenWokSql(Long workId, int start, int num) {
+    private String getAddChildrenWorkSql(Long workId, int start, int num) {
         return "INSERT INTO v1 (id, obj_type, ord) \n" +
         "SELECT DISTINCT v.id, 'W', e.edge_order \n" +
         "FROM vertex v, edge e, property p \n" +

--- a/src/amberdb/query/WorkChildrenQuery.java
+++ b/src/amberdb/query/WorkChildrenQuery.java
@@ -2,7 +2,6 @@ package amberdb.query;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/amberdb/sort/SortField.java
+++ b/src/amberdb/sort/SortField.java
@@ -1,0 +1,117 @@
+package amberdb.sort;
+
+import java.util.Comparator;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import amberdb.model.Work;
+
+public enum SortField {
+    ALIAS ("alias", new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            try {
+                //Null value always last
+                if (CollectionUtils.isEmpty(w1.getAlias())){
+                    return 1;
+                }
+                if (CollectionUtils.isEmpty(w2.getAlias())){
+                    return -1;
+                }
+                return w1.getAlias().get(0).compareTo(w2.getAlias().get(0));
+            } catch (Exception e) {
+                log.error("Bad alias found", e);
+            }
+            return 0;
+        }}, new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            try {
+                //Null value always last
+                if (CollectionUtils.isEmpty(w1.getAlias())){
+                    return 1;
+                }
+                if (CollectionUtils.isEmpty(w2.getAlias())){
+                    return -1;
+                }
+                return w2.getAlias().get(0).compareTo(w1.getAlias().get(0));
+            } catch (Exception e) {
+                log.error("Bad alias found", e);
+            }
+            return 0;
+        }
+    }), 
+    SHEET_NUMBER ("sheetNumber", new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getSheetName() == null){
+                return 1;
+            }
+            if (w2.getSheetName() == null){
+                return -1;
+            }
+            return w1.getSheetName().compareTo(w2.getSheetName());    
+            
+        }}, new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getSheetName() == null){
+                return 1;
+            }
+            if (w2.getSheetName() == null){
+                return -1;
+            }
+            return w2.getSheetName().compareTo(w1.getSheetName()); 
+        }
+    }),
+    ISSUE_DATE ("issueDate", new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getIssueDate() == null){
+                return 1;
+            }
+            if (w2.getIssueDate() == null){
+                return -1;
+            }
+            return w1.getIssueDate().compareTo(w2.getIssueDate());    
+            
+        }}, new Comparator<Work>(){
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getIssueDate() == null){
+                return 1;
+            }
+            if (w2.getIssueDate() == null){
+                return -1;
+            }
+            return w2.getIssueDate().compareTo(w1.getIssueDate());
+        }
+    });
+    
+    private final static Logger log = LoggerFactory.getLogger(SortField.class);
+    String fieldName;
+    Comparator<Work> ascComparator;
+    Comparator<Work> descComparator;
+    
+    private SortField(String fieldName, Comparator<Work> ascComparator, Comparator<Work> descComparator) {
+        this.fieldName = fieldName;
+        this.ascComparator = ascComparator;
+        this.descComparator = descComparator;
+    }
+    
+    public static SortField fromString(String fieldName) {
+        for (SortField field : SortField.values()) {
+            if (field.fieldName.equalsIgnoreCase(fieldName)) {
+                return field;
+            }
+        }
+        return null;
+    }
+    
+}

--- a/src/amberdb/sort/SortField.java
+++ b/src/amberdb/sort/SortField.java
@@ -1,15 +1,18 @@
 package amberdb.sort;
 
 import java.util.Comparator;
+import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
+
 import amberdb.model.Work;
 
-public enum SortField {
-    ALIAS ("alias", new Comparator<Work>(){
+enum SortField {
+    ALIAS ("Alias", new Comparator<Work>(){
         @Override
         public int compare(Work w1, Work w2) {
             try {
@@ -43,56 +46,8 @@ public enum SortField {
             return 0;
         }
     }), 
-    SHEET_NUMBER ("sheetNumber", new Comparator<Work>(){
-        @Override
-        public int compare(Work w1, Work w2) {
-            //Null value always last
-            if (w1.getSheetName() == null){
-                return 1;
-            }
-            if (w2.getSheetName() == null){
-                return -1;
-            }
-            return w1.getSheetName().compareTo(w2.getSheetName());    
-            
-        }}, new Comparator<Work>(){
-        @Override
-        public int compare(Work w1, Work w2) {
-            //Null value always last
-            if (w1.getSheetName() == null){
-                return 1;
-            }
-            if (w2.getSheetName() == null){
-                return -1;
-            }
-            return w2.getSheetName().compareTo(w1.getSheetName()); 
-        }
-    }),
-    ISSUE_DATE ("issueDate", new Comparator<Work>(){
-        @Override
-        public int compare(Work w1, Work w2) {
-            //Null value always last
-            if (w1.getIssueDate() == null){
-                return 1;
-            }
-            if (w2.getIssueDate() == null){
-                return -1;
-            }
-            return w1.getIssueDate().compareTo(w2.getIssueDate());    
-            
-        }}, new Comparator<Work>(){
-        @Override
-        public int compare(Work w1, Work w2) {
-            //Null value always last
-            if (w1.getIssueDate() == null){
-                return 1;
-            }
-            if (w2.getIssueDate() == null){
-                return -1;
-            }
-            return w2.getIssueDate().compareTo(w1.getIssueDate());
-        }
-    });
+    SHEET_NAME ("Sheet Name", new SheetNameComparatorAsc(), new SheetNameComparatorDesc()),
+    ISSUE_DATE ("Issue Date", new IssueDateComparatorAsc(), new IssueDateComparatorDesc());
     
     private final static Logger log = LoggerFactory.getLogger(SortField.class);
     String fieldName;
@@ -105,6 +60,14 @@ public enum SortField {
         this.descComparator = descComparator;
     }
     
+    public static List<String> allSortFields() {
+        List<String> list = Lists.newArrayList();
+        for (SortField sortField : values()){
+            list.add(sortField.fieldName);
+        }
+        return list;
+    }
+    
     public static SortField fromString(String fieldName) {
         for (SortField field : SortField.values()) {
             if (field.fieldName.equalsIgnoreCase(fieldName)) {
@@ -113,5 +76,67 @@ public enum SortField {
         }
         return null;
     }
+    
+    private static abstract class IssueDateComparator implements Comparator<Work>{
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getIssueDate() == null){
+                return 1;
+            }
+            if (w2.getIssueDate() == null){
+                return -1;
+            }
+            return 0;
+        }
+    }
+    
+    private static class IssueDateComparatorAsc extends IssueDateComparator{
+        @Override
+        public int compare(Work w1, Work w2) {
+            int compare = super.compare(w1, w2);
+            return compare == 0 ? w1.getIssueDate().compareTo(w2.getIssueDate()) : compare;
+        }
+    }
+    
+    private static class IssueDateComparatorDesc extends IssueDateComparator{
+        @Override
+        public int compare(Work w1, Work w2) {
+            int compare = super.compare(w1, w2);
+            return compare == 0 ? w2.getIssueDate().compareTo(w1.getIssueDate()) : compare;
+        }
+    }
+    
+    private static abstract class SheetNameComparator implements Comparator<Work>{
+        @Override
+        public int compare(Work w1, Work w2) {
+            //Null value always last
+            if (w1.getSheetName() == null){
+                return 1;
+            }
+            if (w2.getSheetName() == null){
+                return -1;
+            }
+            return 0;
+        }
+    }
+    
+    private static class SheetNameComparatorAsc extends SheetNameComparator{
+        @Override
+        public int compare(Work w1, Work w2) {
+            int compare = super.compare(w1, w2);
+            return compare == 0 ? w1.getSheetName().compareTo(w2.getSheetName()) : compare;
+        }
+    }
+    
+    private static class SheetNameComparatorDesc extends SheetNameComparator{
+        @Override
+        public int compare(Work w1, Work w2) {
+            int compare = super.compare(w1, w2);
+            return compare == 0 ? w2.getSheetName().compareTo(w1.getSheetName()) : compare;
+        }
+    }
+
+    
     
 }

--- a/src/amberdb/sort/SortItem.java
+++ b/src/amberdb/sort/SortItem.java
@@ -1,0 +1,32 @@
+package amberdb.sort;
+
+import java.util.Comparator;
+
+import amberdb.model.Work;
+
+public class SortItem {
+    private final SortField sortField;
+    private final SortOrder sortOrder;
+    public SortItem(SortField sortField, SortOrder sortOrder) {
+        super();
+        this.sortField = sortField;
+        this.sortOrder = sortOrder;
+    }
+    public SortItem(String fieldName, boolean desc){
+        this.sortField = SortField.fromString(fieldName);
+        if (sortField == null){
+            throw new IllegalArgumentException("The field "+fieldName+" is not defined in SortField class");
+        }
+        this.sortOrder = desc ? SortOrder.DESC : SortOrder.ASC; 
+    }
+    
+    public boolean desc() {
+        return sortOrder == SortOrder.DESC;
+    }
+    public String fieldName() {
+        return sortField.fieldName;
+    }
+    public Comparator<Work> compartor() {
+        return desc() ? sortField.descComparator : sortField.ascComparator;
+    }
+}

--- a/src/amberdb/sort/SortItem.java
+++ b/src/amberdb/sort/SortItem.java
@@ -1,6 +1,7 @@
 package amberdb.sort;
 
 import java.util.Comparator;
+import java.util.List;
 
 import amberdb.model.Work;
 
@@ -28,5 +29,9 @@ public class SortItem {
     }
     public Comparator<Work> compartor() {
         return desc() ? sortField.descComparator : sortField.ascComparator;
+    }
+    
+    public static List<String> allSortFields() {
+        return SortField.allSortFields();
     }
 }

--- a/src/amberdb/sort/SortItem.java
+++ b/src/amberdb/sort/SortItem.java
@@ -27,7 +27,7 @@ public class SortItem {
     public String fieldName() {
         return sortField.fieldName;
     }
-    public Comparator<Work> compartor() {
+    public Comparator<Work> comparator() {
         return desc() ? sortField.descComparator : sortField.ascComparator;
     }
     

--- a/src/amberdb/sort/SortOrder.java
+++ b/src/amberdb/sort/SortOrder.java
@@ -1,0 +1,5 @@
+package amberdb.sort;
+
+public enum SortOrder {
+    ASC, DESC;
+}

--- a/src/amberdb/sort/SortOrder.java
+++ b/src/amberdb/sort/SortOrder.java
@@ -1,5 +1,5 @@
 package amberdb.sort;
 
-public enum SortOrder {
+enum SortOrder {
     ASC, DESC;
 }

--- a/test/amberdb/query/WorkChildrenQueryTest.java
+++ b/test/amberdb/query/WorkChildrenQueryTest.java
@@ -1,8 +1,6 @@
 package amberdb.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -94,9 +92,8 @@ public class WorkChildrenQueryTest {
         assertEquals(sections.size(), 7);
         sess.setLocalMode(false);
     }        
-    
 
-    private Work buildWork() {
+    private Work buildWork(){
         Work parent = sess.addWork();
         
         for (int i = 0; i < 20; i++) {
@@ -144,5 +141,6 @@ public class WorkChildrenQueryTest {
         
         return parent;
     }
+   
 
 }

--- a/test/amberdb/sort/SortFieldTest.java
+++ b/test/amberdb/sort/SortFieldTest.java
@@ -1,0 +1,49 @@
+package amberdb.sort;
+
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import amberdb.model.Work;
+
+public class SortFieldTest {
+
+    private Work work1, work2, work3, work4, work5;
+    
+    @Before
+    public void setup(){
+        work1 = mock(Work.class);
+        work2 = mock(Work.class);
+        work3 = mock(Work.class);
+        work4 = mock(Work.class);
+        work5 = mock(Work.class);
+    }
+    
+    @Test
+    public void aliasSort() throws Exception{
+        when(work1.getAlias()).thenReturn(new ArrayList<String>());
+        when(work2.getAlias()).thenReturn(Arrays.asList("abc002"));
+        when(work3.getAlias()).thenReturn(Arrays.asList("abc001"));
+        when(work4.getAlias()).thenReturn(null);
+        when(work5.getAlias()).thenReturn(Arrays.asList("abc004", "abc000"));
+        List<Work> work = new ArrayList<>(Arrays.asList(work1, work2, work3, work4, work5));
+        Collections.sort(work, SortField.ALIAS.ascComparator);
+        assertThat(work.get(0).getAlias(), hasItem("abc001"));
+        assertThat(work.get(2).getAlias(), hasItem("abc004"));
+        assertThat(CollectionUtils.isEmpty(work.get(3).getAlias()), is(true));
+        assertThat(CollectionUtils.isEmpty(work.get(4).getAlias()), is(true));
+        Collections.sort(work, SortField.ALIAS.descComparator);
+        assertThat(work.get(0).getAlias(), hasItem("abc004"));
+        assertThat(work.get(2).getAlias(), hasItem("abc001"));
+        assertThat(CollectionUtils.isEmpty(work.get(3).getAlias()), is(true));
+        assertThat(CollectionUtils.isEmpty(work.get(4).getAlias()), is(true));
+    }
+    
+
+}


### PR DESCRIPTION
http://ourweb.nla.gov.au/apps/jira/browse/DSCS-1134
@scoen @AaronCMuller @danielbaker 
- Add a new query based on the getChildRange() to return a subset of children sorted by certain field
- @scoen , the original query wasn't changed. Just refactored a bit to fit in my query
- Unfortunately, the new query isn't unit testable due to
1) ISNULL() function is not recognised by jdbi
2) The order by field must be in the SELECT clause in jdbi (while not required by MySQL)
So the query has been tested in Banjo instead
- The banjo PR is coming out soon. Please review along with the banjo PR. 