### PR TITLE
If an exception occurs while running ImageMagick manipulations, ignor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-AmberDB                       
+AmberDB
 =======
 
-###Latest AmberDb snapshot version : 1.5.4-SNAPSHOT
+###Latest AmberDb snapshot version : 1.5.5-SNAPSHOT
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)
 
@@ -16,7 +16,7 @@ A graph domain model on top of SQL for representing digital library objects and 
 * History keeping and history subscription for indexing
 * Ordered edges
 
-Usage 
+Usage
 -----
 
 In-memory:
@@ -37,7 +37,7 @@ try (AmberDb db = new AmberDb(Paths.get("/tmp/mygraph")) {
 
 Remote JDBC:
 
-```TODO    
+```TODO
 ```
 
 ======

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.5.4-SNAPSHOT</version>
+  <version>1.5.5-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/util/Jp2Converter.java
+++ b/src/amberdb/util/Jp2Converter.java
@@ -35,7 +35,7 @@ import com.drew.metadata.exif.ExifIFD0Directory;
  *  - For colour images with more than 3 channels (RGB): turn them in to 3 channels (RGB).
  *  - For colour images with 16 or 24 bitdepth: turn bitdepth into 8.
  *  - For colour images with a colour palette (photometric > 2): strip off the colour palette.
- * 
+ *
  * It's also noticed that some colour images (tiff) can't be converted to the standard jp2 due to kakadu file format support.
  * Kakadu recommends converting them to .jpx instead:
  *     Error in Kakadu File Format Support:
@@ -117,7 +117,11 @@ public class Jp2Converter {
                 // Uncompress image as the demo app kdu_compress can't process compressed tiff
                 convertUncompress(srcFilePath, tmpFilePath);
             }
+        } catch (Exception e) {
+            log.warn("Exception occurred when attempting to manipulate image into a JP2'able state.");
+        }
 
+        try {
             Path fileToCreateJp2 = Files.exists(tmpFilePath) ? tmpFilePath : srcFilePath;
 
             // Create jp2 using kakadu kdu_compress


### PR DESCRIPTION
…e it and try to generate the JP2 anyway.

The reason why we're going to ignore it is because it looks like ImageMagick will sometimes produce warnings that don't effect the outcome, but still cause an exception to be thrown. If the JP2 generation actually fails, then we will bail out.

@ninhnguyen @JonathanShaw @scoen 

I managed to generate a fine jp2 with the errors that I was seeing are below:

<pre>convert: Unknown field with tag 34016 (0x84e0) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34017 (0x84e1) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34018 (0x84e2) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34019 (0x84e3) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34020 (0x84e4) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34021 (0x84e5) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34022 (0x84e6) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34023 (0x84e7) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34024 (0x84e8) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34025 (0x84e9) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34026 (0x84ea) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34027 (0x84eb) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34028 (0x84ec) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34029 (0x84ed) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34030 (0x84ee) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: Unknown field with tag 34031 (0x84ef) encountered. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/851.
convert: nla.obj-19191692-m.tif: Null count for "Tag 34022" (type 1, writecount -3, passcount 1). `_TIFFVSetField' @ error/tiff.c/TIFFErrors/561.
convert: nla.obj-19191692-m.tif: Null count for "Tag 34025" (type 1, writecount -3, passcount 1). `_TIFFVSetField' @ error/tiff.c/TIFFErrors/561.
convert: nla.obj-19191692-m.tif: Null count for "Tag 34026" (type 1, writecount -3, passcount 1). `_TIFFVSetField' @ error/tiff.c/TIFFErrors/561.
convert: nla.obj-19191692-m.tif: Null count for "Tag 34031" (type 1, writecount -3, passcount 1). `_TIFFVSetField' @ error/tiff.c/TIFFErrors/561.
</pre>