### PR TITLE
Added a new fields to Work and File

### DIFF
--- a/src/amberdb/model/File.java
+++ b/src/amberdb/model/File.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.codehaus.jackson.JsonParseException;
@@ -91,6 +92,18 @@ public interface File extends Node {
 
     @Property("checksumType")
     public String getChecksumType();
+    
+    /**
+     * Set the date/time that the checksum was generated.
+     */
+    @Property("checksumGenerationDate")
+    public void setChecksumGenerationDate(Date date);
+
+    /**
+     * Get the date/time the checksum was generated.
+     */
+    @Property("checksumGenerationDate")
+    public Date getChecksumGenerationDate();
     
     @Property("device")
     public String getDevice();

--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -430,6 +430,18 @@ public interface Work extends Node {
     
     @Property("sheetCreationDate")
     void setSheetCreationDate(Date sheetCreationDate);
+    
+    /**
+     * Get the vendor identifier that was assigned by the E-Deposit app.
+     */
+    @Property("vendorId")
+    String getVendorId();
+    
+    /**
+     * Set the vendor identifier that was assigned by the E-Deposit app.
+     */
+    @Property("vendorId")
+    void setVendorId(String id);
 
     @Adjacency(label = DescriptionOf.label, direction = Direction.IN)
     GeoCoding addGeoCoding();

--- a/test/amberdb/model/FileTest.java
+++ b/test/amberdb/model/FileTest.java
@@ -3,6 +3,7 @@ package amberdb.model;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Date;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,5 +33,16 @@ public class FileTest {
         File file = copy.addFile();
         assertEquals(0L, file.getFileSize());
         assertEquals(0L, file.getSize());
+    }
+    
+    @Test
+    public void shouldReturnTheChecksumCreationDate() {
+        Work work = amberDb.addWork();
+        Copy copy = work.addCopy();
+        File file = copy.addFile();
+        
+        Date date = new Date();
+        file.setChecksumGenerationDate(date);
+        assertEquals(date, file.getChecksumGenerationDate());
     }
 }

--- a/test/amberdb/model/WorkTest.java
+++ b/test/amberdb/model/WorkTest.java
@@ -381,6 +381,11 @@ public class WorkTest {
         assertTrue(deliveryWork.getDeliveryWorkParent().equals(work));
     }
     
+    @Test
+    public void testVendorIdWasSet() {
+        assertEquals("101", bookBlinkyBill.getVendorId());
+    }
+    
     private void setTestDataInH2(AmberSession sess) {
         workCollection = sess.addWork();
         
@@ -395,6 +400,7 @@ public class WorkTest {
         bookBlinkyBill.setBibLevel(BibLevel.ITEM.code());
         bookBlinkyBill.setCopyrightPolicy(CopyrightPolicy.OUTOFCOPYRIGHT.code());
         bookBlinkyBill.setDigitalStatus(CaptureStatus.CAPTURED.code());
+        bookBlinkyBill.setVendorId("101");
         workCollection.addChild(bookBlinkyBill);
         
         chapterBlinkyBill = sess.addWork();


### PR DESCRIPTION
This change adds a new "checksum generation date" field to File.  This is the date that the checksum was generated by either Banjo or an external application. The E-Deposit application will include this data when it submits files to Banjo

A new "vendor id" field has been added to Work. Vendor id is generated by the E-Deposit application and needs to be included in the data sent to Voyager.
@scoen 