### PR TITLE
Remove IOExceptions thrown from Json deserialization.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.6.2-SNAPSHOT</version>
+  <version>1.6.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>
@@ -157,16 +157,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
-    </dependency>
-        <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>persistence-api</artifactId>
       <version>1.0.2</version>

--- a/src/amberdb/AmberSession.java
+++ b/src/amberdb/AmberSession.java
@@ -1,46 +1,16 @@
 package amberdb;
 
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.sql.DataSource;
-
 import amberdb.graph.*;
-import org.apache.commons.lang.StringUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.skife.jdbi.v2.DBI;
-
-import amberdb.model.CameraData;
-import amberdb.model.Copy;
-import amberdb.model.Description;
-import amberdb.model.EADWork;
-import amberdb.model.File;
-import amberdb.model.GeoCoding;
-import amberdb.model.IPTC;
-import amberdb.model.ImageFile;
-import amberdb.model.Page;
-import amberdb.model.Party;
-import amberdb.model.Section;
-import amberdb.model.SoundFile;
-import amberdb.model.Tag;
-import amberdb.model.Work;
+import amberdb.graph.AmberMultipartQuery.QueryClause;
+import amberdb.model.*;
 import amberdb.sql.ListLu;
 import amberdb.sql.Lookups;
 import amberdb.sql.LookupsSchema;
-import amberdb.graph.AmberMultipartQuery.QueryClause;
-
-import static amberdb.graph.BranchType.*;
-
-import com.google.common.collect.Lists;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.blueprints.TransactionalGraph;
@@ -53,8 +23,18 @@ import com.tinkerpop.frames.FramedGraphFactory;
 import com.tinkerpop.frames.modules.gremlingroovy.GremlinGroovyModule;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerModule;
 import com.tinkerpop.frames.modules.typedgraph.TypedGraphModuleBuilder;
-
 import doss.BlobStore;
+import org.apache.commons.lang.StringUtils;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.skife.jdbi.v2.DBI;
+
+import javax.sql.DataSource;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+import static amberdb.graph.BranchType.BRANCH_FROM_ALL;
+import static amberdb.graph.BranchType.BRANCH_FROM_PREVIOUS;
 
 
 public class AmberSession implements AutoCloseable {

--- a/src/amberdb/DataIntegrityException.java
+++ b/src/amberdb/DataIntegrityException.java
@@ -1,0 +1,16 @@
+package amberdb;
+
+public class DataIntegrityException extends RuntimeException {
+
+    public DataIntegrityException() {
+        super();
+    }
+
+    public DataIntegrityException(String message) {
+        super(message);
+    }
+
+    public DataIntegrityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/amberdb/model/Copy.java
+++ b/src/amberdb/model/Copy.java
@@ -1,38 +1,17 @@
 package amberdb.model;
 
-import java.lang.ProcessBuilder.Redirect;
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.channels.FileChannel;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import amberdb.relation.*;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringUtils;
-import org.apache.tika.Tika;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import amberdb.AmberSession;
 import amberdb.NoSuchCopyException;
 import amberdb.enums.CopyRole;
+import amberdb.relation.*;
 import amberdb.util.Jp2Converter;
 import amberdb.util.PdfTransformerFop;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
@@ -40,12 +19,25 @@ import com.tinkerpop.frames.Property;
 import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
-
 import doss.Blob;
 import doss.BlobStore;
 import doss.NoSuchBlobException;
 import doss.Writable;
 import doss.core.Writables;
+import org.apache.commons.lang.StringUtils;
+import org.apache.tika.Tika;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.ProcessBuilder.Redirect;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.*;
 
 
 /**
@@ -53,58 +45,58 @@ import doss.core.Writables;
  * one or more copies of a work, e.g. the original paper version of a piece of
  * sheet music, a microform replica and a set of digital replicas made from
  * either the original or the microform copy.
- * 
+ *
  * Copies may be either original or derived manually or automatically from
  * another copy. For the purposes of the digital library if the source of a
  * derivative is unknown we consider it original.
  */
 @TypeValue("Copy")
 public interface Copy extends Node {
-    
+
     /* DCM Legacy Data */
     @Property("dcmCopyPid")
     public String getDcmCopyPid();
 
     @Property("dcmCopyPid")
     public void setDcmCopyPid(String dcmCopyPid);
-    
+
     @Property("dcmSourceCopy")
     public String getDcmSourceCopy();
 
     @Property("dcmSourceCopy")
     public void setDcmSourceCopy(String dcmSourceCopy);
-    
+
     @Property("dcmDateTimeCreated")
     public Date getDcmDateTimeCreated();
 
     @Property("dcmDateTimeCreated")
     public void setDcmDateTimeCreated(Date dcmDateTimeCreated);
-    
+
     @Property("dcmDateTimeUpdated")
     public Date getDcmDateTimeUpdated();
 
     @Property("dcmDateTimeUpdated")
     public void setDcmDateTimeUpdated(Date dcmDateTimeUpdated);
-    
+
     @Property("dcmRecordCreator")
     public String getDcmRecordCreator();
 
     @Property("dcmRecordCreator")
     public void setDcmRecordCreator(String dcmRecordCreator);
-    
+
     @Property("dcmRecordUpdater")
     public String getDcmRecordUpdater();
 
     @Property("dcmRecordUpdater")
     public void setDcmRecordUpdater(String dcmRecordUpdater);
     /* END DCM Legacy Data */
-    
+
     @Property("currentVersion")
     public String getCurrentVersion();
 
     @Property("currentVersion")
     public void setCurrentVersion(String currentVersion);
-    
+
     @Property("versionNumber")
     public String getVersionNumber();
 
@@ -116,7 +108,7 @@ public interface Copy extends Node {
 
     @Property("copyType")
     public void setCopyType(String copyType);
-    
+
     @Property("copyRole")
     public String getCopyRole();
 
@@ -128,25 +120,25 @@ public interface Copy extends Node {
 
     @Property("carrier")
     public void setCarrier(String carrier);
-    
+
     @Property("algorithm")
     public String getAlgorithm();
-    
+
     @Property("algorithm")
     public void setAlgorithm(String algorithm);
-        
+
     @Property("bestCopy")
     public String getBestCopy();
 
     @Property("bestCopy")
     public void setBestCopy(String bestCopy);
-    
+
     @Property("materialType")
     public String getMaterialType();
 
     @Property("materialType")
     public void setMaterialType(String materialType);
-    
+
     @Property("dateCreated")
     public Date getDateCreated();
 
@@ -158,7 +150,7 @@ public interface Copy extends Node {
 
     @Property("condition")
     public void setCondition(String condition);
-    
+
     @Property("exhibition")
     public String getExhibition();
 
@@ -170,16 +162,16 @@ public interface Copy extends Node {
 
     @Property("copyStatus")
     public void setCopyStatus(String copyStatus);
-    
+
     @Property("timedStatus")
     public String getTimedStatus();
 
     @Property("timedStatus")
     public void setTimedStatus(String timedStatus);
-    
+
     @Property("segmentIndicator")
     public String getSegmentIndicator();
-    
+
     @Property("segmentIndicator")
     public void setSegmentIndicator(String segmentIndicator);
 
@@ -199,33 +191,33 @@ public interface Copy extends Node {
      */
     @Property("otherNumbers")
     public String getOtherNumbers();
-    
+
 
     /**
      * This method handles the JSON deserialisation of the OtherNumbers Property
-     * @throws IOException 
-     * @throws JsonMappingException 
-     * @throws JsonParseException 
+     * @throws IOException
+     * @throws JsonMappingException
+     * @throws JsonParseException
      */
     @JavaHandler
     public Map<String, String> getAllOtherNumbers() throws JsonParseException, JsonMappingException, IOException;
-    
+
     /**
      * This property is encoded as a JSON Hash - You probably want to use setAllOtherNumbers to set this property
      */
     @Property("otherNumbers")
     public void setOtherNumbers(String otherNumbers);
- 
+
     /**
      * This method handles the JSON serialisation of the OtherNumbers Property
-     * @throws IOException 
-     * @throws JsonMappingException 
-     * @throws JsonParseException 
+     * @throws IOException
+     * @throws JsonMappingException
+     * @throws JsonParseException
      */
     @JavaHandler
     public void setAllOtherNumbers(Map<String, String> otherNumbers) throws JsonParseException, JsonMappingException, IOException;
 
-    
+
     /**
      * The source copy which this copy was derived from. Null if this copy is
      * original or the source copy is unknown.
@@ -235,7 +227,7 @@ public interface Copy extends Node {
 
     @Adjacency(label = IsSourceCopyOf.label, direction=Direction.IN)
     public Iterable<Copy> getDerivatives();
-    
+
     @JavaHandler
     public Iterable<Copy> getDerivatives(CopyRole copyRole);
 
@@ -256,28 +248,28 @@ public interface Copy extends Node {
 
     @Adjacency(label = IsFileOf.label, direction = Direction.IN)
     public File getFile();
-    
+
     @JavaHandler
     public CameraData getCameraData();
-    
+
     @JavaHandler
     public ImageFile getImageFile();
 
     @JavaHandler
     public SoundFile getSoundFile();
-    
+
     @Adjacency(label = DescriptionOf.label, direction = Direction.IN)
     public CameraData addCameraData();
-    
+
     @Adjacency(label = IsFileOf.label, direction = Direction.IN)
     public File addFile();
-    
+
     @Adjacency(label = IsFileOf.label, direction = Direction.IN)
     public ImageFile addImageFile();
 
     @Adjacency(label = IsFileOf.label, direction = Direction.IN)
     public SoundFile addSoundFile();
-    
+
     @JavaHandler
     File addFile(Path source, String mimeType) throws IOException;
 
@@ -286,35 +278,35 @@ public interface Copy extends Node {
 
     @JavaHandler
     File addFile(Writable contents, String mimeType) throws IOException;
-    
+
     @Adjacency(label = IsFileOf.label, direction = Direction.IN)
     void removeFile(final File file);
 
     @Adjacency(label = IsCopyOf.label)
     public Work getWork();
-    
+
     @Adjacency(label = Represents.label)
     public Iterable<Work> getRepresentedWorks();
-    
+
     @JavaHandler
     Copy deriveJp2ImageCopy(Path jp2Converter, Path imgConverter) throws IllegalStateException, IOException, InterruptedException, Exception;
 
     @JavaHandler
     Copy derivePdfCopy(Path pdfConverter, Path stylesheet, Path altStylesheet) throws IllegalStateException, NoSuchBlobException, IOException, InterruptedException;
-    
+
     @JavaHandler
     Copy derivePdfCopy(CopyRole copyRole, Reader... stylesheets) throws IOException;
 
     @JavaHandler
     int getCurrentIndex();
-    
+
     abstract class Impl extends Node.Impl implements JavaHandlerContext<Vertex>, Copy {
         static final Logger log = LoggerFactory.getLogger(Copy.class);
         static ObjectMapper mapper = new ObjectMapper();
-        
+
         @Override
         public File addFile(Path source, String mimeType) throws IOException {
-           return addFile(Writables.wrap(source), mimeType);             
+           return addFile(Writables.wrap(source), mimeType);
         }
 
         @Override
@@ -430,7 +422,7 @@ public interface Copy extends Node {
                 }
             }
         }
-        
+
         @Override
         public Copy derivePdfCopy(CopyRole copyRole, Reader... stylesheets) throws IOException {
             File file = this.getFile();
@@ -439,7 +431,7 @@ public interface Copy extends Node {
             if (!file.getMimeType().equals("application/xml")) {
                 throw new RuntimeException("Failed to generate pdf copy for work " + getWork().getObjId() + " as this copy " + getObjId() + " is not an xml file.");
             }
-            
+
             Copy pdfCopy = this.getWork().addCopy();
             pdfCopy.setCopyRole(copyRole.code());
             pdfCopy.setSourceCopy(this);
@@ -447,7 +439,7 @@ public interface Copy extends Node {
             pdfCopy.addFile(Writables.wrap(pdfContent), "application/pdf");
             return pdfCopy;
         }
-        
+
         @Override
         public Copy derivePdfCopy(Path pdfConverter, Path stylesheet, Path altStylesheet) throws IllegalStateException, NoSuchBlobException, IOException, InterruptedException {
             File eadFile = this.getFile();
@@ -458,16 +450,16 @@ public interface Copy extends Node {
             try {
                 // create a temporary file processing location for generating pdf
                 stage = Files.createTempDirectory("amberdb-derivative");
-                
+
                 // assume this Copy is a FINDING_AID_COPY
                 Long blobId = this.getFile().getBlobId();
-                
+
                 // get this copy's blob store...
                 BlobStore doss = AmberSession.ownerOf(g()).getBlobStore();
-                
+
                 // pdf finally...
                 Path pdfPath = generatePdf(doss, pdfConverter, stylesheet, altStylesheet, stage, blobId);
-                
+
                 // add the derived pdf copy
                 Copy pc = null;
                 if (pdfPath != null) {
@@ -500,14 +492,14 @@ public interface Copy extends Node {
                 Long blobId) throws NoSuchBlobException, IOException, InterruptedException {
             if (blobId == null)
                 throw new NoSuchCopyException(this.getWork().getId(), CopyRole.fromString(getCopyRole()));
-            
+
             // prepare file for conversion
             Path eadPath = stage.resolve(blobId + ".xml"); // where to put the ead xml from the amber
             copyBlobToFile(doss.get(blobId), eadPath);
-            
+
             // pdf file
             Path pdfPath = stage.resolve(blobId + ".pdf"); // name the pdf derivative after the original blob id
-            
+
             // Convert to pdf
             convertToPDF(pdfConverter, stylesheet, altStylesheet, eadPath, pdfPath);
             return pdfPath;
@@ -535,9 +527,9 @@ public interface Copy extends Node {
                         pdfPath.toString()
                 });
             }
-            
+
         }
-        
+
         // Execute a command
         private void executeCmd(String[] cmd) throws IOException, InterruptedException {
             // Log command
@@ -561,13 +553,13 @@ public interface Copy extends Node {
             if (otherNumbers == null || otherNumbers.isEmpty())
                 return new HashMap<String,String>();
             return mapper.readValue(otherNumbers, new TypeReference<Map<String, String>>() { } );
-            
+
         }
-        
+
         @Override
         public Iterable<Copy> getDerivatives(CopyRole copyRole) {
             Iterable<Copy> copies = getDerivatives();
-            List<Copy> limitedCopies = new ArrayList<>(); 
+            List<Copy> limitedCopies = new ArrayList<>();
             if (copies != null) {
                 for (Copy copy : copies) {
                     if (copy.getCopyRole().equals(copyRole.code())) {
@@ -590,21 +582,21 @@ public interface Copy extends Node {
          */
         @Deprecated
         private Path generateImage(BlobStore doss, Path tiffUncompressor, Path jp2Generator, Path stage, Long tiffBlobId) throws IOException, InterruptedException, NoSuchCopyException {
-            
+
             if (tiffBlobId == null)
                 throw new NoSuchCopyException(this.getWork().getId(), CopyRole.fromString(this.getCopyRole()));
 
             // prepare the files for conversion
             Path tiffPath = stage.resolve(tiffBlobId + ".tif");                                 // where to put the tif retrieved from the amber blob
-            Path uncompressedTiffPath = stage.resolve("uncompressed_" + tiffBlobId + ".tif");   // what to call the uncompressed tif 
+            Path uncompressedTiffPath = stage.resolve("uncompressed_" + tiffBlobId + ".tif");   // what to call the uncompressed tif
             copyBlobToFile(doss.get(tiffBlobId), tiffPath);                                     // get the blob from amber
 
             // Step 1: uncompress tiff
             String[] uncompressCmd = {
                     tiffUncompressor.toString(),
                     "-c",
-                    "none", 
-                    tiffPath.toString(), 
+                    "none",
+                    tiffPath.toString(),
                     uncompressedTiffPath.toString()};
 
             ProcessBuilder uncompressPb = new ProcessBuilder(uncompressCmd);
@@ -612,10 +604,10 @@ public interface Copy extends Node {
             Process uncompressProcess = uncompressPb.start();
             uncompressProcess.waitFor();
             int uncompressResult = uncompressProcess.exitValue();
-            
+
             // Step 2: generate and store JP2 image on DOSS
             Path jp2ImgPath = stage.resolve(tiffBlobId + ".jp2"); // name the jpeg2000 derivative after the original uncompressed blob
-            
+
             // This can be shifted out to config down the track
             String[] convertCmd = {
                     jp2Generator.toString(),
@@ -728,56 +720,56 @@ public interface Copy extends Node {
 
         private long copyBlobToFile(Blob blob, Path destinationFile) throws IOException {
             long bytesTransferred = 0;
-            try (ReadableByteChannel channel = blob.openChannel(); 
+            try (ReadableByteChannel channel = blob.openChannel();
                     FileChannel dest = FileChannel.open(
-                            destinationFile, 
-                            StandardOpenOption.WRITE, 
-                            StandardOpenOption.CREATE, 
+                            destinationFile,
+                            StandardOpenOption.WRITE,
+                            StandardOpenOption.CREATE,
                             StandardOpenOption.TRUNCATE_EXISTING)) {
                 bytesTransferred = dest.transferFrom(channel, 0, Long.MAX_VALUE);
             }
             return bytesTransferred;
         }
-        
+
         @Override
         public CameraData getCameraData() {
             Description o = getDescription("CameraData");
             return (o == null) ? null : this.g().frame(o.asVertex(), CameraData.class);
         }
-        
+
         @Override
         public ImageFile getImageFile() {
             File o = getSpecializedFile("image");
             return (o == null) ? null : this.g().frame(o.asVertex(), ImageFile.class);
         }
-        
+
         @Override
         public SoundFile getSoundFile() {
             File o = getSpecializedFile("audio");
             return (o == null) ? null : this.g().frame(o.asVertex(), SoundFile.class);
         }
-        
+
         private File getSpecializedFile(String fmt) {
             String fileType = "";
             if (fmt.equals("image"))
                 fileType = "ImageFile";
             else if (fmt.equals("audio"))
                 fileType = "SoundFile";
-            
+
             Iterable<File> files = this.getFiles();
             if (files != null) {
                 Iterator<File> it = files.iterator();
                 while (it.hasNext()) {
                     File next = it.next();
-                    if (next.getType().equals(fileType) || 
+                    if (next.getType().equals(fileType) ||
                             (next.getMimeType() != null && next.getMimeType().startsWith(fmt))) {
                         return next;
                     }
                 }
             }
             return null;
-        }    
-        
+        }
+
         @Override
         public List<String> getManipulation() throws JsonParseException, JsonMappingException, IOException {
             String manipulation = getJSONManipulation();

--- a/src/amberdb/model/EADWork.java
+++ b/src/amberdb/model/EADWork.java
@@ -1,14 +1,9 @@
 package amberdb.model;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-
+import amberdb.NoSuchObjectException;
+import amberdb.relation.IsPartOf;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.frames.Adjacency;
@@ -17,10 +12,11 @@ import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.frames.modules.typedgraph.TypeValue;
 
-import amberdb.NoSuchObjectException;
-import amberdb.model.Work;
-import amberdb.relation.DescriptionOf;
-import amberdb.relation.IsPartOf;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 
 @TypeValue("EADWork")
 public interface EADWork extends Work {

--- a/src/amberdb/model/File.java
+++ b/src/amberdb/model/File.java
@@ -1,5 +1,23 @@
 package amberdb.model;
 
+import amberdb.AmberSession;
+import amberdb.relation.DescriptionOf;
+import amberdb.relation.IsFileOf;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.frames.Adjacency;
+import com.tinkerpop.frames.Property;
+import com.tinkerpop.frames.modules.javahandler.JavaHandler;
+import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
+import com.tinkerpop.frames.modules.typedgraph.TypeValue;
+import doss.*;
+import doss.core.Writables;
+import doss.local.LocalBlobStore;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.SeekableByteChannel;
@@ -7,31 +25,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
-import amberdb.AmberSession;
-import amberdb.relation.IsFileOf;
-import amberdb.relation.DescriptionOf;
-
-import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.frames.Adjacency;
-import com.tinkerpop.frames.Property;
-import com.tinkerpop.frames.modules.javahandler.JavaHandler;
-import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
-import com.tinkerpop.frames.modules.typedgraph.TypeValue;
-
-import doss.Blob;
-import doss.BlobStore;
-import doss.BlobTx;
-import doss.NoSuchBlobException;
-import doss.Writable;
-import doss.core.Writables;
-import doss.local.LocalBlobStore;
 
 @TypeValue("File")
 public interface File extends Node {
@@ -47,7 +40,7 @@ public interface File extends Node {
 
     @Property("mimeType")
     public String getMimeType();
-    
+
     /**
      * Name of the original file upload
      */
@@ -56,43 +49,43 @@ public interface File extends Node {
 
     @Property("fileName")
     public String getFileName();
-    
+
     @Property("fileFormat")
     public void setFileFormat(String fileFormat);
 
     @Property("fileFormat")
     public String getFileFormat();
-    
+
     @Property("fileFormatVersion")
     public void setFileFormatVersion(String fileFormatVersion);
 
     @Property("fileFormatVersion")
     public String getFileFormatVersion();
-    
+
     @Property("fileSize")
     public void setFileSize(long fileSize);
 
     @JavaHandler
     public long getFileSize();
-    
+
     @Property("compression")
     public void setCompression(String compression);
 
     @Property("compression")
     public String getCompression();
-    
+
     @Property("checksum")
     public void setChecksum(String checksum);
 
     @Property("checksum")
     public String getChecksum();
-    
+
     @Property("checksumType")
     public void setChecksumType(String checksumType);
 
     @Property("checksumType")
     public String getChecksumType();
-    
+
     /**
      * Set the date/time that the checksum was generated.
      */
@@ -104,37 +97,37 @@ public interface File extends Node {
      */
     @Property("checksumGenerationDate")
     public Date getChecksumGenerationDate();
-    
+
     @Property("device")
     public String getDevice();
-    
+
     @Property("device")
     public void setDevice(String device);
-    
+
     @Property("deviceSerialNumber")
     public String getDeviceSerialNumber();
 
     @Property("deviceSerialNumber")
     public void setDeviceSerialNumber(String deviceSerialNumber);
-    
+
     @Property("software")
     public String getSoftware();
-    
+
     @Property("software")
     public void setSoftware(String software);
-    
+
     @Property("softwareSerialNumber")
     public String getSoftwareSerialNumber();
-    
+
     @Property("softwareSerialNumber")
     public void setSoftwareSerialNumber(String softwareSerialNumber);
-    
+
     @Property("encoding")
     public String getEncoding();
-    
+
     @Property("encoding")
     public void setEncoding(String encoding);
-    
+
     /**
      * This property is encoded as a JSON Array - You probably want to use getToolId to get this property
      */
@@ -164,16 +157,16 @@ public interface File extends Node {
      */
     @JavaHandler
     public void setToolId(List<Long> toolId) throws JsonParseException, JsonMappingException, IOException;
-    
+
     /*
      * Fields migrated from DCM
      */
     @Property("dcmCopyPid")
     public String getDcmCopyPid();
-    
+
     @Property("dcmCopyPid")
     public void setDcmCopyPid(String dcmCopyPid);
-   
+
     @Adjacency(label = IsFileOf.label)
     public Copy getCopy();
 
@@ -211,15 +204,15 @@ public interface File extends Node {
             }
             return getBlobStore().get(getBlobId());
         }
-        
+
         @Override
         public long getFileSize() {
             Long fileSize = this.asVertex().getProperty("fileSize");
-            return (fileSize == null)? 0L : fileSize;  
+            return (fileSize == null)? 0L : fileSize;
         }
-        
+
         /**
-         * Return the size of the blob. If an exception occurs try and 
+         * Return the size of the blob. If an exception occurs try and
          * return the fileSize property. If that fails, return 0L.
          */
         @Override

--- a/src/amberdb/model/Node.java
+++ b/src/amberdb/model/Node.java
@@ -1,21 +1,17 @@
 package amberdb.model;
 
-import java.io.IOException;
-
-import java.util.*;
-
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
+import amberdb.DataIntegrityException;
 import amberdb.PIUtil;
 import amberdb.graph.AmberGraph;
 import amberdb.graph.AmberTransaction;
 import amberdb.graph.AmberVertex;
 import amberdb.relation.DescriptionOf;
 import amberdb.relation.Tags;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.util.wrappers.wrapped.WrappedVertex;
@@ -26,11 +22,14 @@ import com.tinkerpop.frames.modules.javahandler.JavaHandler;
 import com.tinkerpop.frames.modules.javahandler.JavaHandlerContext;
 import com.tinkerpop.frames.modules.typedgraph.TypeField;
 
+import java.io.IOException;
+import java.util.*;
+
 @TypeField("type")
 public interface Node extends VertexFrame {
-    
+
     /**
-     * Access Conditions determine whether or not something can be 
+     * Access Conditions determine whether or not something can be
      * displayed to the public. Also known as Public Availability
      * Values: Restricted, Unrestricted, Internal access only
      */
@@ -38,34 +37,34 @@ public interface Node extends VertexFrame {
     public String getAccessConditions();
 
     /**
-     * Access Conditions determine whether or not something can be 
+     * Access Conditions determine whether or not something can be
      * displayed to the public. Also known as Public Availability
      * Values: Restricted, Unrestricted, Internal access only
      */
     @Property("accessConditions")
     public void setAccessConditions(String accessConditions);
-    
+
     /**
-     * Internal Access Conditions reflect display and access 
+     * Internal Access Conditions reflect display and access
      * for internal content management applications.
      * Values: open, restricted, closed
      */
     @Property("internalAccessConditions")
     public String getInternalAccessConditions();
-    
+
     /**
-    * Internal Access Conditions reflect display and access      
+    * Internal Access Conditions reflect display and access
     * for internal content management applications.
     * Values: open, restricted, closed
     */
     @Property("internalAccessConditions")
     public void setInternalAccessConditions(String internalAccessConditions);
-    
+
     /**
      * get the expiry date of the access conditions.
-     * @return the expiry date.  
+     * @return the expiry date.
      * Note: the expiry date is currently for display only, not enforced
-     *       for the checking of the access conditions. 
+     *       for the checking of the access conditions.
      */
     @Property("expiryDate")
     public Date getExpiryDate();
@@ -78,54 +77,54 @@ public interface Node extends VertexFrame {
      */
     @Property("expiryDate")
     public void setExpiryDate(Date expiryDate);
-    
+
     @Property("restrictionType")
     public String getRestrictionType();
 
     @Property("restrictionType")
     public void setRestrictionType(String restrictionType);
-    
+
     @Property("notes")
     public String getNotes();
 
     @Property("notes")
     public void setNotes(String notes);
-    
+
     @Property("type")
     public String getType();
-    
+
   @JavaHandler
   abstract public long getId();
-  
+
   @JavaHandler
   abstract public String getObjId();
-  
+
     /**
      * This property is encoded as a JSON Array - You probably want to use getAlias to get this property
      */
     @Property("alias")
     public String getJSONAlias();
-    
+
     /**
      * This property is encoded as a JSON Array - You probably want to use setAlias to set this property
      */
     @Property("alias")
     public void setJSONAlias(String alias);
-    
+
     /**
      * This method handles the JSON serialisation of the OtherNumbers Property
-     * @throws IOException 
-     * @throws JsonMappingException 
-     * @throws JsonParseException 
+     * @throws IOException
+     * @throws JsonMappingException
+     * @throws JsonParseException
      */
     @JavaHandler
     public void setAlias(List<String> alias) throws JsonParseException, JsonMappingException, IOException;
-    
+
     /**
      * This method handles the JSON deserialisation of the OtherNumbers Property
-     * @throws IOException 
-     * @throws JsonMappingException 
-     * @throws JsonParseException 
+     * @throws IOException
+     * @throws JsonMappingException
+     * @throws JsonParseException
      */
     @JavaHandler
     public List<String> getAlias() throws JsonParseException, JsonMappingException, IOException;
@@ -141,7 +140,7 @@ public interface Node extends VertexFrame {
 
     @Property("localSystemNumber")
     public void setLocalSystemNumber(String localSystemNumber);
-    
+
     @Property("commentsInternal")
     public String getCommentsInternal();
 
@@ -159,38 +158,38 @@ public interface Node extends VertexFrame {
 
     @JavaHandler
     public void addCommentsExternal(String comment);
-    
+
     @Adjacency(label = DescriptionOf.label, direction= Direction.IN)
     public Iterable<Description> getDescriptions();
-    
+
     @Adjacency(label = Tags.label, direction = Direction.IN)
     public Iterable<Tag> getTags();
-    
+
     @Adjacency(label = Tags.label, direction = Direction.IN)
     public void addTag(final Tag tag);
 
     @Adjacency(label = Tags.label, direction = Direction.IN)
     public void removeTag(final Tag tag);
-    
+
     @JavaHandler
     public Description getDescription(String fmt);
-    
+
     @JavaHandler
     public <T extends Description> List<T> getDescriptions(Class<T> returnClass);
-        
+
     @JavaHandler
     public AmberGraph getAmberGraph();
-    
+
     @JavaHandler
     public AmberTransaction getFirstTransaction();
-    
+
     @JavaHandler
     public AmberTransaction getLastTransaction();
-    
+
     /**
      * Set the edge-order attribute on the edge with the given label that
      * connects from this node to the adjacent node.
-     * 
+     *
      * @param adjacent
      *            The adjacent node
      * @param label
@@ -206,13 +205,13 @@ public interface Node extends VertexFrame {
     /**
      * Get the edge-order attribute on the edge with the given label that
      * connects from this node to the adjacent node.
-     * 
+     *
      * @param adjacent
      *            The adjacent node
      * @param label
      *            The label of the edge whose edge order will be returned
      * @param direction
-     *            The direction of the edge (wrt this Node) whose order will be returned  
+     *            The direction of the edge (wrt this Node) whose order will be returned
      * @return An order value or null if no edges conform to requirements
      */
     @JavaHandler
@@ -289,7 +288,7 @@ public interface Node extends VertexFrame {
             }
             return null;
         }
-        
+
         @Override
         public <T extends Description> List<T> getDescriptions(Class<T> returnClass) {
             Iterable<Description> descriptions = this.getDescriptions();
@@ -298,7 +297,7 @@ public interface Node extends VertexFrame {
             List<T> entries = new ArrayList<>();
             Iterator<Description> it = descriptions.iterator();
             while (it.hasNext()) {
-                Description next = it.next();  
+                Description next = it.next();
                 if (next.getType() != null && (next.getType().equals(returnClass.getName()) || (next.getType().equals(returnClass.getSimpleName())))) {
                     entries.add(this.g().getVertex(next.asVertex().getId(), returnClass));
                 }
@@ -307,15 +306,21 @@ public interface Node extends VertexFrame {
         }
 
         @Override
-        public List<String> getAlias() throws JsonParseException, JsonMappingException, IOException {
+        public List<String> getAlias() {
             String alias = getJSONAlias();
             if (alias == null || alias.isEmpty())
-                return new ArrayList<String>();
-            return mapper.readValue(alias, new TypeReference<List<String>>() {});
+                return new ArrayList<>();
+            try {
+                return mapper.readValue(alias, new TypeReference<List<String>>() {
+                });
+            }
+            catch (IOException e) {
+                throw new DataIntegrityException("Could not read deserialize alias", e);
+            }
         }
 
         @Override
-        public void setAlias(List<String> alias) throws JsonParseException, JsonMappingException, IOException {
+        public void setAlias(List<String> alias) throws JsonProcessingException {
             setJSONAlias(mapper.writeValueAsString(alias));
         }
 

--- a/src/amberdb/model/builder/Document.java
+++ b/src/amberdb/model/builder/Document.java
@@ -1,36 +1,37 @@
 package amberdb.model.builder;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.IOException;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 
 public class Document {
     final JsonNode document;
     final ObjectMapper mapper = new ObjectMapper();
-    
+
     public Document(JsonNode structure, JsonNode content) {
         this.document = mapper.createObjectNode();
         ((ObjectNode) document).put("structure", structure);
         ((ObjectNode) document).put("content", content);
     }
-    
+
     public JsonNode getStructure() {
         return document.get("structure");
     }
-    
+
     public JsonNode getContent() {
         return document.get("content");
     }
-    
+
     public JsonNode getReport() {
         return document.get("report");
     }
-    
+
     public void setStatusReport(JsonNode report) {
         ((ObjectNode) document).put("report", report);
     }
-    
+
     public String toJson() throws IOException {
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(document);
     }

--- a/test/amberdb/IngestTest.java
+++ b/test/amberdb/IngestTest.java
@@ -1,29 +1,21 @@
 package amberdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import amberdb.enums.CopyRole;
+import amberdb.model.Page;
+import amberdb.model.Work;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Edge;
-
-import amberdb.enums.CopyRole;
-import amberdb.model.Page;
-import amberdb.model.Work;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public class IngestTest {
@@ -178,21 +170,21 @@ public class IngestTest {
 
         // show the qa form
         try {
-            
+
             Page p1;
             Page p2;
-            
+
             if (work.countParts() > 1) {
-                
+
                 p1 = work.getPage(1);
                 p2 = work.getPage(2);
-                
+
                 Page a = work.getPage(1);
                 Page b = work.getPage(2);
-                
+
                 a.setOrder(2);
                 b.setOrder(1);
-                
+
                 assertEquals(p1, work.getPage(2));
                 assertEquals(p2, work.getPage(1));
             }
@@ -203,7 +195,7 @@ public class IngestTest {
                 page.crop(100, 100, 200, 200);
                 page.setTitle("IV");
             }
-            
+
             assertEquals(work.getPage(1).getTitle(), "IV");
 
         } catch (Exception e) {

--- a/test/amberdb/model/EADWorkTest.java
+++ b/test/amberdb/model/EADWorkTest.java
@@ -1,28 +1,27 @@
 package amberdb.model;
 
-import static org.junit.Assert.*;
+import amberdb.AmberSession;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.junit.Before;
-import org.junit.Test;
-
-import amberdb.AmberSession;
+import static org.junit.Assert.assertEquals;
 
 public class EADWorkTest {
     private EADWork componentWork;
     private AmberSession db;
-    
+
     @Before
     public void setup() throws IOException, InstantiationException {
         db = new AmberSession();
         setTestDataInH2(db);
     }
-    
+
     @Test
     public void testSetEADProperties() throws JsonParseException, JsonMappingException, IOException {
         String expectedRdsType = "Sponsor";
@@ -30,7 +29,7 @@ public class EADWorkTest {
         String expectedEADReviewYN = "Y";
         String[] items = { "box-6" };
         List<String> expectedFolder = Arrays.asList(items);
-        
+
         componentWork.setRdsAcknowledgementType(expectedRdsType);
         componentWork.setRdsAcknowledgementReceiver(expectedRdsReceiver);
         componentWork.setEADUpdateReviewRequired(expectedEADReviewYN);
@@ -40,10 +39,10 @@ public class EADWorkTest {
         assertEquals(expectedEADReviewYN, componentWork.getEADUpdateReviewRequired());
         assertEquals(expectedFolder, componentWork.getFolder());
     }
-    
+
     private void setTestDataInH2(AmberSession db) {
         EADWork collectionWork = db.addWork().asEADWork();
-        componentWork = collectionWork.addEADWork(); 
+        componentWork = collectionWork.addEADWork();
         componentWork.setSubType("series");
         componentWork.setTitle("Papers of Leslie Greener");
     }


### PR DESCRIPTION
The rationale here is that if any exception occurs deserializing a json property, it probably means that the data somehow isn't actually json, and we should fail hard, rather than having to deal with IOExceptions everywhere.

This also removes outdated versions of jackson that were being used rather than the newer (already imported) versions.

@scoen 