### PR TITLE
Updated Work.setOrder() so that it doesn't throw a NullPointerException

### DIFF
--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -1441,7 +1441,10 @@ public interface Work extends Node {
 
         @Override
         public void setOrder(int position) {
-            getParentEdge().setRelOrder(position);
+            IsPartOf parentEdge = getParentEdge();
+            if (parentEdge != null) {
+                parentEdge.setRelOrder(position);
+            }
         }
 
         @Override

--- a/test/amberdb/model/WorkTest.java
+++ b/test/amberdb/model/WorkTest.java
@@ -517,6 +517,24 @@ public class WorkTest {
         assertTrue(constraints.contains("octopus"));
     }
     
+    @Test
+    public void testSetOrder() {
+        Work work = db.addWork();
+        work.setOrder(0);  // should not throw a NullPointerException
+        
+        Work child1 = db.addWork();
+        work.addChild(child1);
+        Work child2 = db.addWork();
+        work.addChild(child2);
+        
+        child2.setOrder(0);
+        child1.setOrder(1);
+        
+        Iterator<Work> it = work.getChildren().iterator();
+        assertEquals(child2, it.next());
+        assertEquals(child1, it.next());
+    }
+    
     @After
     public void teardown() throws IOException {
         if (db != null)


### PR DESCRIPTION
Updated Work.setOrder() so that it doesn't throw a NullPointerException when the work doesn't have a parent.

@scoen @AaronCMuller 