### PR TITLE
ms1911: add new query to retrieve first and last transactions given a list of work ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.9.1-SNAPSHOT</version>
+  <version>1.9.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/graph/AmberVertexTransaction.java
+++ b/src/amberdb/graph/AmberVertexTransaction.java
@@ -1,0 +1,40 @@
+package amberdb.graph;
+
+public class AmberVertexTransaction {
+
+    AmberTransaction transaction;
+    long vertexId;
+    
+    
+    public AmberVertexTransaction(long transactionId, Long time, String user, String operation, long vertexId) {
+        this.transaction = new AmberTransaction(transactionId, time, user, operation);
+        this.vertexId = vertexId;
+    }
+
+    public AmberTransaction getTransaction() {
+        return transaction;
+    }
+
+
+    public void setTransaction(AmberTransaction transaction) {
+        this.transaction = transaction;
+    }
+
+
+    public long getVertexId() {
+        return vertexId;
+    }
+
+
+    public void setVertexId(long vertexId) {
+        this.vertexId = vertexId;
+    }
+
+    @Override
+    public String toString() {
+        return "AmberVertexTransaction{" +
+                "transaction=" + transaction +
+                ", vertexId=" + vertexId +
+                '}';
+    }
+}

--- a/src/amberdb/graph/VertexTransactionMapper.java
+++ b/src/amberdb/graph/VertexTransactionMapper.java
@@ -1,0 +1,24 @@
+package amberdb.graph;
+
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+
+public class VertexTransactionMapper implements ResultSetMapper<AmberVertexTransaction> {
+    
+    
+    public AmberVertexTransaction map(int index, ResultSet rs, StatementContext ctx)
+            throws SQLException {
+
+        return new AmberVertexTransaction(
+                rs.getLong("transaction_id"), 
+                rs.getLong("time"), 
+                rs.getString("user"),
+                rs.getString("operation"),
+                rs.getLong("vertex_id"));
+    }
+}

--- a/src/amberdb/query/WorksQuery.java
+++ b/src/amberdb/query/WorksQuery.java
@@ -1,12 +1,11 @@
 package amberdb.query;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
+import amberdb.graph.*;
+import amberdb.relation.DeliveredOn;
+import amberdb.relation.IsPartOf;
+import org.apache.commons.collections.CollectionUtils;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.ByteArrayMapper;
 
@@ -16,10 +15,6 @@ import com.tinkerpop.blueprints.Vertex;
 
 import amberdb.AmberSession;
 import amberdb.enums.BibLevel;
-import amberdb.graph.AmberProperty;
-import amberdb.graph.AmberQuery;
-import amberdb.graph.BranchType;
-import amberdb.graph.DataType;
 import amberdb.model.Copy;
 import amberdb.model.Work;
 
@@ -35,15 +30,38 @@ public class WorksQuery {
     }
     
     public static Map<Long, Work> getWorksMap(AmberSession sess, List<Long> ids) {
-        Map<Long, Work> works = new HashMap<Long, Work>();
-        List<Vertex> verts = sess.getAmberGraph().newQuery(ids).execute();
+        Map<Long, Work> works = new HashMap();
+        AmberQuery query = sess.getAmberGraph().newQuery(ids);
+        query.branch(BranchType.BRANCH_FROM_PREVIOUS, Arrays.asList(IsPartOf.label), Direction.OUT);
+        query.branch(BranchType.BRANCH_FROM_LISTED, Arrays.asList(DeliveredOn.label), Direction.IN, Arrays.asList(0));
+        Map<Long, AmberTransaction> firstTransactionMap = getFirstTransactions(sess, ids);
+        Map<Long, AmberTransaction> lastTransactionMap = getLastTransactions(sess, ids);
+        List<Vertex> verts = query.execute();
         for (Vertex v : verts) {
             Work work = sess.getGraph().frame(v, Work.class);
+            populateFirstTransactionDetails(work, firstTransactionMap);
+            populateLastTransactionDetails(work, lastTransactionMap);
             works.put(Long.valueOf(work.getId()), work);
         }
         return works;
     }
-    
+
+    private static void populateFirstTransactionDetails(Work work, Map<Long, AmberTransaction> map) {
+        AmberTransaction transaction = map.get(work.getId());
+        if (transaction != null) {
+            work.asVertex().setProperty("createdOn", new Date(transaction.getTime()));
+            work.asVertex().setProperty("createdBy", transaction.getUser());
+        }
+    }
+
+    private static void populateLastTransactionDetails(Work work, Map<Long, AmberTransaction> map) {
+        AmberTransaction transaction = map.get(work.getId());
+        if (transaction != null) {
+            work.asVertex().setProperty("modifiedOn", new Date(transaction.getTime()));
+            work.asVertex().setProperty("modifiedBy", transaction.getUser());
+        }
+    }
+
     public static List<Copy> getCopiesWithWorks(AmberSession sess, List<Long> copyIds) {
         List<Copy> copies = new ArrayList<>();
         AmberQuery query = sess.getAmberGraph().newQuery(copyIds);
@@ -105,5 +123,39 @@ public class WorksQuery {
             }
         }
         return bibLevels;
+    }
+    
+    private static Map<Long, AmberTransaction> getFirstTransactions(AmberSession sess, List<Long> workIds){
+        if (CollectionUtils.isNotEmpty(workIds)) {
+            String sql = "select t1.time, t1.user, t1.operation, t2.transaction_id, t2.vertex_id " +
+                    "from transaction t1, (select min(t.id) transaction_id, v.id vertex_id from transaction t, vertex v " +
+                    "where t.id = v.txn_start and v.id in (" + Joiner.on(",").join(workIds) + ") group by v.id) " +
+                    "as t2 where t1.id = t2.transaction_id";
+            return getTransactions(sess, sql);
+        }
+        return new HashMap<>();
+    }
+
+    private static Map<Long, AmberTransaction> getLastTransactions(AmberSession sess, List<Long> workIds){
+        if (CollectionUtils.isNotEmpty(workIds)) {
+            String sql = "select t1.time, t1.user, t1.operation, t2.transaction_id, t2.vertex_id " +
+                    "from transaction t1, (select max(t.id) transaction_id, v.id vertex_id from transaction t, vertex v " +
+                    "where t.id = v.txn_start and v.id in (" + Joiner.on(",").join(workIds) + ") group by v.id) " +
+                    "as t2 where t1.id = t2.transaction_id";
+            return getTransactions(sess, sql);
+        }
+        return new HashMap<>();
+    }
+
+    private static Map<Long, AmberTransaction> getTransactions(AmberSession sess, String sql){
+        Map<Long, AmberTransaction> map = new HashMap<>();
+        List<AmberVertexTransaction> list;
+        try (Handle h = sess.getAmberGraph().dbi().open()) {
+            list = h.createQuery(sql).map(new VertexTransactionMapper()).list();
+        }
+        for (AmberVertexTransaction transaction : list) {
+            map.put(transaction.getVertexId(), transaction.getTransaction());
+        }
+        return map;
     }
 }


### PR DESCRIPTION
@scoen 
http://ourweb.nla.gov.au/apps/jira/browse/DSCS-1911
I can only think of this straightforward way --- call custom queries to load all transactions upfront, then assign property to each work. I have tested it and it seems to get the job done. Took 1.5 seconds to export 8901 items. 
Related to https://github.com/nla/banjo/pull/1844