### PR TITLE
Update DOSS and some dependencies to stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.10.0-SNAPSHOT</version>
+  <version>1.10.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>au.gov.nla</groupId>
       <artifactId>doss</artifactId>
-      <version>1.0.5</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jdbi</groupId>
@@ -87,12 +87,12 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.172</version>
+      <version>1.3.176</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.25</version>
+      <version>5.1.38</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.flyway</groupId>
@@ -134,12 +134,12 @@
     <dependency>
       <groupId>com.jolbox</groupId>
       <artifactId>bonecp</artifactId>
-      <version>0.7.1.RELEASE</version>
+      <version>0.8.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
 - doss 1.0.5 to 1.1.0
 - h2 1.3.172 to 1.3.176
 - mysql-connector-java 5.1.25 to 5.1.38 (banjo .25 needs updating or removing)
 - bonecp 0.8.1-RELEASE to 0.8.0-RELEASE (matches banjo)
 - apache-commons-lang3 3.1 to 3.4 (banjo 3.2 needs updating or removing)
 - update amberdb SNAPSHOT version to 1.10.1