### PR TITLE
retained h2 as upgrade require more testing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.3.172</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
H2 v1.3.176 introduced a number of new features that requires more testing, so retained h2 to be at v1.3.172 for now.
@scoen could you please review this change?  thanks.