### PR TITLE
Ms2026: More getChildren() to be refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AmberDB
 =======
 
-###Latest AmberDb snapshot version : 1.10.2-SNAPSHOT
+###Latest AmberDb snapshot version : 1.10.3-SNAPSHOT
 ###Latest AmberDb release version  : 1.10.0-RELEASE
 
 [<img src="http://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Ant_in_amber.jpg/320px-Ant_in_amber.jpg" align="right">](http://commons.wikimedia.org/wiki/File:Ant_in_amber.jpg)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>au.gov.nla</groupId>
   <artifactId>amberdb</artifactId>
-  <version>1.10.2-SNAPSHOT</version>
+  <version>1.10.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>amberdb</name>
   <description>Digital library domain model</description>

--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -6,12 +6,10 @@ import amberdb.InvalidSubtypeException;
 import amberdb.enums.CopyRole;
 import amberdb.enums.CopyType;
 import amberdb.enums.SubType;
-import amberdb.graph.AmberEdge;
 import amberdb.graph.AmberGraph;
 import amberdb.graph.AmberQuery;
 import amberdb.graph.AmberVertex;
 import amberdb.relation.*;
-import amberdb.util.WorkUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +21,6 @@ import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.util.wrappers.wrapped.WrappedEdge;
 import com.tinkerpop.blueprints.util.wrappers.wrapped.WrappedVertex;
 import com.tinkerpop.frames.Adjacency;
 import com.tinkerpop.frames.Incidence;
@@ -1183,17 +1180,6 @@ public interface Work extends Node {
     @JavaHandler
     void orderParts(List<Work> parts);
 
-    /**
-     *
-     * Returns the work that contains the access copy to be used for this work's representative image.
-     *
-     * @return The work with the image copy that should be used to represent this work, or null if no image is
-     * specified.
-     *
-     */
-    @JavaHandler
-    Work getRepresentativeImageWork();
-
     @JavaHandler
     List<String> getJsonList(String propertyName);
 
@@ -1706,41 +1692,6 @@ public interface Work extends Node {
         @Override
         public void addRepresentation(final Copy copy) {
             addRepresentative(copy);
-        }
-
-        @Override
-        public Work getRepresentativeImageWork() {
-
-            Work repImageOrAccessCopy = getRepImageOrAccessCopy(this);
-            if (repImageOrAccessCopy != null) {
-                return repImageOrAccessCopy;
-            }
-
-            Iterable<Work> children = getChildren();
-            if (!children.iterator().hasNext()) {
-                return null;
-            }
-            Work child = Iterables.get(children, 0);
-            if (WorkUtils.checkCanReturnRepImage(child)) {
-                return getRepImageOrAccessCopy(child);
-            }
-            return null;
-        }
-
-        private static Work getRepImageOrAccessCopy(Work work) {
-            Iterator<Copy> representations = work.getRepresentations().iterator();
-            if (representations.hasNext()) {
-                Work repWork = representations.next().getWork();
-                if (!WorkUtils.checkCanReturnRepImage(repWork)) {
-                    return null;
-                }
-                return repWork;
-            }
-            Copy accessCopy = work.getCopy(CopyRole.ACCESS_COPY);
-            if (accessCopy != null && accessCopy.getImageFile() != null) {
-                return work;
-            }
-            return null;
         }
 
         @Override

--- a/src/amberdb/util/RepresentativeImageHelper.java
+++ b/src/amberdb/util/RepresentativeImageHelper.java
@@ -1,0 +1,51 @@
+package amberdb.util;
+
+import amberdb.AmberSession;
+import amberdb.enums.CopyRole;
+import amberdb.model.Copy;
+import amberdb.model.Work;
+import amberdb.query.WorkChildrenQuery;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class RepresentativeImageHelper {
+
+    /**
+     * Returns the work that contains the access copy to be used for this work's representative image.
+     *
+     * @return The work with the image copy that should be used to represent this work, or null if no image is
+     * specified.
+     */
+    public static Work getRepresentativeImageWork(Work work, AmberSession amberSession){
+        Work repImageOrAccessCopy = getRepImageOrAccessCopy(work);
+        if (repImageOrAccessCopy != null) {
+            return repImageOrAccessCopy;
+        }
+        WorkChildrenQuery query = new WorkChildrenQuery(amberSession);
+        List<Work> children = query.getChildRange(work.getId(), 0, 1);
+        if (!children.isEmpty()) {
+            Work child = children.get(0);
+            if (WorkUtils.checkCanReturnRepImage(child)) {
+                return getRepImageOrAccessCopy(child);
+            }
+        }
+        return null;
+    }
+
+    private static Work getRepImageOrAccessCopy(Work work) {
+        Iterator<Copy> representations = work.getRepresentations().iterator();
+        if (representations.hasNext()) {
+            Work repWork = representations.next().getWork();
+            if (!WorkUtils.checkCanReturnRepImage(repWork)) {
+                return null;
+            }
+            return repWork;
+        }
+        Copy accessCopy = work.getCopy(CopyRole.ACCESS_COPY);
+        if (accessCopy != null && accessCopy.getImageFile() != null) {
+            return work;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
@scoen 
http://ourweb.nla.gov.au/apps/jira/browse/DSCS-2026
- getRepresentativeImageWork()  calls getChildren() method, which slows things down. Write a utility method to do its job. 

Related to https://github.com/nla/banjo/pull/1901 and https://github.com/nla/dl-repository-service/pull/113