### PR TITLE
ms2026: put representativeImageWork as a property

### DIFF
--- a/src/amberdb/model/Work.java
+++ b/src/amberdb/model/Work.java
@@ -1729,36 +1729,7 @@ public interface Work extends Node {
 
         @Override
         public Work getRepresentativeImageWork() {
-            Work repImageOrAccessCopy = getRepImageOrAccessCopy(this);
-            if (repImageOrAccessCopy != null) {
-                return repImageOrAccessCopy;
-            }
-
-           Iterable<Work> children = getChildren();
-            if (!children.iterator().hasNext()) {
-                return null;
-            }
-            Work child = Iterables.get(children, 0);
-            if (WorkUtils.checkCanReturnRepImage(child)) {
-                return getRepImageOrAccessCopy(child);
-           }
-            return null;
-        }
-
-        private static Work getRepImageOrAccessCopy(Work work) {
-            Iterator<Copy> representations = work.getRepresentations().iterator();
-            if (representations.hasNext()) {
-                Work repWork = representations.next().getWork();
-               if (!WorkUtils.checkCanReturnRepImage(repWork)) {
-                    return null;
-                }
-                return repWork;
-            }
-            Copy accessCopy = work.getCopy(CopyRole.ACCESS_COPY);
-            if (accessCopy != null && accessCopy.getImageFile() != null) {
-                return work;
-            }
-            return null;
+            return (Work)this.asVertex().getProperty("representativeImageWork");
         }
 
         @Override

--- a/src/amberdb/util/RepresentativeImageHelper.java
+++ b/src/amberdb/util/RepresentativeImageHelper.java
@@ -32,6 +32,10 @@ public class RepresentativeImageHelper {
         }
         return null;
     }
+    
+    public static void setRepresentativeImageWorkProperty(Work work, AmberSession amberSession){
+        work.asVertex().setProperty("representativeImageWork", getRepresentativeImageWork(work, amberSession));
+    }
 
     private static Work getRepImageOrAccessCopy(Work work) {
         Iterator<Copy> representations = work.getRepresentations().iterator();


### PR DESCRIPTION
@scoen 
- In the controller put representativeImageWork as a vertex property for the template to retrieve. 
Related to https://github.com/nla/banjo/pull/1902
