### PR TITLE
ms2026: null check of representative image work

### DIFF
--- a/src/amberdb/util/RepresentativeImageHelper.java
+++ b/src/amberdb/util/RepresentativeImageHelper.java
@@ -34,7 +34,10 @@ public class RepresentativeImageHelper {
     }
     
     public static void setRepresentativeImageWorkProperty(Work work, AmberSession amberSession){
-        work.asVertex().setProperty("representativeImageWork", getRepresentativeImageWork(work, amberSession));
+        Work representativeImageWork = getRepresentativeImageWork(work, amberSession);
+        if (representativeImageWork != null){
+            work.asVertex().setProperty("representativeImageWork", representativeImageWork);    
+        }
     }
 
     private static Work getRepImageOrAccessCopy(Work work) {


### PR DESCRIPTION
Urgent PR
Banjo show work screen is broken for those works without representative images. 