### PR TITLE
DDG-83: Added new edeposit values to the Constraint lookup table.

### DIFF
--- a/migrations/lookupValues_update_3.sql
+++ b/migrations/lookupValues_update_3.sql
@@ -1,0 +1,3 @@
+INSERT INTO lookups (name, code, value, deleted) VALUES('constraint', 'edeposit online access coming soon', 'edeposit online access coming soon' , 'N');
+INSERT INTO lookups (name, code, value, deleted) VALUES('constraint', 'edeposit online access after embargo', 'edeposit online access after embargo' , 'N');
+INSERT INTO lookups (name, code, value, deleted) VALUES('constraint', 'edeposit library access coming soon', 'edeposit library access coming soon' , 'N');


### PR DESCRIPTION
For the initial edeposit release, the business area has decided to add 3 new access constraints that can be assigned to Copy.  These values will probably change in future after the edeposit release to production.  I'm not sure if this migration will run automatically or whether manual intervention is required.
@scoen @JonathanShaw @shuangzhou 