### PR TITLE
Added specific SQL query for trove article indexing.

### DIFF
--- a/src/amberdb/AmberSession.java
+++ b/src/amberdb/AmberSession.java
@@ -584,6 +584,10 @@ public class AmberSession implements AutoCloseable {
         return getAmberHistory().getModifiedObjectIds(from);
     }
 
+    public ModifiedObjectsQueryResponse getArticlesForIndexing(ModifiedObjectsQueryRequest request) {
+        return getAmberHistory().getArticlesForIndexing(request);
+    }
+    
     public ModifiedObjectsQueryResponse getModifiedObjectIds(ModifiedObjectsQueryRequest request) {
         return getAmberHistory().getModifiedObjectIds(request);
     }

--- a/src/amberdb/graph/AmberHistory.java
+++ b/src/amberdb/graph/AmberHistory.java
@@ -146,6 +146,19 @@ public class AmberHistory {
             }
         }));
     }
+    
+    public ModifiedObjectsQueryResponse getArticlesForIndexing(ModifiedObjectsQueryRequest request) {
+        ObjectsQuery query = new ObjectsQuery(graph);
+
+        return query.getArticlesForIndexing(new ModifiedObjectsBetweenTransactionsQueryRequest(request, new ModifiedObjectsBetweenTransactionsQueryRequest.TransactionsBetweenFinder() {
+            
+            @Override
+            public List<Long> getTransactionsBetween(Date startTime, Date endTime) {
+                return getTxnsBetween(startTime, endTime);
+            }
+        }));
+        
+    }
 
     private Set<VersionedVertex> getWorksForObject(Long id, Set<VersionedVertex> works) {
         

--- a/src/amberdb/query/ModifiedObjectsQueryResponse.java
+++ b/src/amberdb/query/ModifiedObjectsQueryResponse.java
@@ -4,6 +4,8 @@ import java.util.LinkedHashMap;
 
 public class ModifiedObjectsQueryResponse {
     private LinkedHashMap<Long, String> modifiedObjects;
+    private LinkedHashMap<Long, String> reasons;
+
     private boolean hasMore;
     private long skipForNextBatch;
 
@@ -11,20 +13,29 @@ public class ModifiedObjectsQueryResponse {
         this(new LinkedHashMap<Long, String>(), false, -1);
     }
 
-    public ModifiedObjectsQueryResponse(LinkedHashMap<Long, String> modifiedObjects, boolean hasMore, long skipForNextBatch) {
+    public ModifiedObjectsQueryResponse(LinkedHashMap<Long, String> modifiedObjects, LinkedHashMap< Long, String> reasons, boolean hasMore, long skipForNextBatch) {
         this.modifiedObjects = modifiedObjects;
+        this.reasons = reasons;
         this.hasMore = hasMore;
         this.skipForNextBatch = skipForNextBatch;
+    }
+
+    public ModifiedObjectsQueryResponse(LinkedHashMap<Long, String> modifiedObjects, boolean hasMore, long skipForNextBatch) {
+        this(modifiedObjects, new LinkedHashMap<Long, String>(), hasMore, skipForNextBatch);
     }
 
     public LinkedHashMap<Long, String> getModifiedObjects() {
         return modifiedObjects;
     }
-    
+
+    public LinkedHashMap<Long, String> getReasons() {
+        return reasons;
+    }
+
     public long getResultSize() {
         return modifiedObjects.size();
     }
-    
+
     public boolean hasMore() {
         return hasMore;
     }


### PR DESCRIPTION
 Generic query combined with amber was still too slow for prod.

Translated the logic that was previously in java into sql so we can more efficiently get the data trove needs for indexing.

This monstrous query is very specifically just for this and could be optimised a lot I think.  But it's a lot faster than before.

Related dl-trove-service pull request: https://github.com/nla/dl-trove-service/pull/35

@terenceingram @scoen @yetti @shuangzhou @JonathanShaw @sjacob @MingtaoSun @weijunnla @jrixon 