### PR TITLE
Bump tika from 1.4 to 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.4</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>com.drewnoakes</groupId>


### PR DESCRIPTION
Needed for DSCS-2180 to allow extraction of text from .docx and .xlsx files.