### PR TITLE
ms2191: fix catalogue report

### DIFF
--- a/src/amberdb/query/ObjectsQuery.java
+++ b/src/amberdb/query/ObjectsQuery.java
@@ -214,9 +214,10 @@ public class ObjectsQuery extends AmberQueryBase {
                 if (request.hasFilterPredicate()) {
                     vGraph.clear();
                     VersionedVertex vv = vGraph.getVertex(id);
-                    
-                    if (request.getFilterPredicate().apply(vv)) {
-                        modifiedObjects.put(id, transition);
+                    if (vv != null){
+                        if (request.getFilterPredicate().apply(vv)) {
+                            modifiedObjects.put(id, transition);
+                        }    
                     }
                 } else {
                     modifiedObjects.put(id, transition);

--- a/src/amberdb/query/ObjectsQuery.java
+++ b/src/amberdb/query/ObjectsQuery.java
@@ -214,11 +214,9 @@ public class ObjectsQuery extends AmberQueryBase {
                 if (request.hasFilterPredicate()) {
                     vGraph.clear();
                     VersionedVertex vv = vGraph.getVertex(id);
-                    if (vv != null){
-                        if (request.getFilterPredicate().apply(vv)) {
-                            modifiedObjects.put(id, transition);
-                        }    
-                    }
+                    if (vv != null && request.getFilterPredicate().apply(vv)) {
+                        modifiedObjects.put(id, transition);
+                    } 
                 } else {
                     modifiedObjects.put(id, transition);
                 }

--- a/src/amberdb/version/VersionedGraph.java
+++ b/src/amberdb/version/VersionedGraph.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -275,7 +276,7 @@ public class VersionedGraph {
                 .bind("id", vId)
                 .map(new TVertexMapper()).list();
 
-            if (vertices == null) return null;
+            if (CollectionUtils.isEmpty(vertices)) return null;
             
             Map<TId, Map<String, Object>> propMap = getElementPropertyMap(vId, h);
             for (TVertex tv : vertices) {


### PR DESCRIPTION
@josephcurtis @terenceingram 
http://ourweb.nla.gov.au/apps/jira/browse/DSCS-2191

Some vertex ids still exist in edge table while they have been hard deleted from property/vertex table. This has caused some of the catalogue generation to fail. 

Hey Jo @josephcurtis , care to quickly review and merge so that I can generate the report for the business user? thanks
