### PR TITLE
put back begin transaction where it used to be

### DIFF
--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -250,7 +250,7 @@ public class AmberGraph extends BaseGraph
 
     
     public Long suspend() {
-        dao.begin();
+        
         Long sessId = null;
         if (getModifiedElementCount() > BIG_COMMIT_THRESHOLD) {
             log.warn("Graph to be committed exceeds {} elements. Using big suspend to process.",
@@ -271,6 +271,8 @@ public class AmberGraph extends BaseGraph
 
             log.debug("batches -- vertices:{} edges:{} properties:{}",
                     v.id.size(), e.id.size(), p.id.size());
+            
+            dao.begin();
 
             dao.suspendEdges(sessId, e.id, e.txnStart, e.txnEnd, e.vertexOut,
                     e.vertexIn, e.label, e.order, e.state);


### PR DESCRIPTION
I am putting the dao.begin() where it used to be(prior the previous change), as there is currently an issue in devel with suspending normal transactions, this is the only obvious change made. Need this looked at urgently as there is an issue in devel.
@JonathanShaw , @shuangzhou , @jrixon , @MingtaoSun , @weijunnla 