### PR TITLE
Fix suspend

### DIFF
--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -14,7 +14,6 @@ import org.h2.jdbcx.JdbcConnectionPool;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Transaction;
-import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionStatus;
 
 import amberdb.graph.dao.AmberDao;
@@ -276,7 +275,9 @@ public class AmberGraph extends BaseGraph
 
             log.debug("batches -- vertices:{} edges:{} properties:{}",
                     v.id.size(), e.id.size(), p.id.size());
+            
             dao.begin();
+            
             dao.suspendEdges(sessId, e.id, e.txnStart, e.txnEnd, e.vertexOut,
                     e.vertexIn, e.label, e.order, e.state);
             dao.suspendVertices(sessId, v.id, v.txnStart, v.txnEnd, v.state);
@@ -918,7 +919,7 @@ public class AmberGraph extends BaseGraph
         final Long sessId = newId();
         dao.inTransaction(new Transaction<Object, AmberDao>() {
             @Override
-            public Object inTransaction(AmberDao amberDao,
+            public Object inTransaction(AmberDao dao,
                     TransactionStatus transactionStatus) throws Exception {
                 bigSuspendEdges(sessId);
                 bigSuspendVertices(sessId);
@@ -931,6 +932,7 @@ public class AmberGraph extends BaseGraph
         return sessId;
     }
 
+    
     public Long commitBig(String user, String operation) {
 
         Long txnId = suspendBig();

--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -917,15 +917,14 @@ public class AmberGraph extends BaseGraph
 
         // set up batch sql data structures
         final Long sessId = newId();
-        dao.inTransaction(new Transaction<Object, AmberDao>() {
+        dao.inTransaction(new Transaction<Long, AmberDao>() {
             @Override
-            public Object inTransaction(AmberDao dao,
+            public Long inTransaction(AmberDao dao,
                     TransactionStatus transactionStatus) throws Exception {
                 bigSuspendEdges(sessId);
                 bigSuspendVertices(sessId);
                 log.info("finished big suspend");
-                // No need to return anything here
-                return null;
+                return sessId;
             }
         });
 


### PR DESCRIPTION
As Alex suggested ,  put  bigSuspend into dao.inTransaction so the Transaction is committed if execution terminates normally (no exception), but rolled back if an exception is thrown by code. @shuangzhou, @weijunnla , @ato , @MingtaoSun , @jrixon , @JonathanShaw 