### PR TITLE
Sc file size

### DIFF
--- a/src/amberdb/model/File.java
+++ b/src/amberdb/model/File.java
@@ -256,8 +256,8 @@ public interface File extends Node {
          * then goes to the blob to get the file's size. If getting the size from the blob
          * is successful (or if this file vertex has no blob).
          *
-         * This method's side-effect is to set's the fileSize attribute to that reported
-         * by the blob, or sets fileSize to 0 if this file has no blob.
+         * This method's side-effect is to set the fileSize attribute to that reported by
+         * the blob, or sets fileSize to 0 if this file has no blob.
          *
          * If an IOException occurs, this method returns 0 without a side effect.
          *

--- a/test/amberdb/graph/AmberHistoryTransactionsSinceTest.java
+++ b/test/amberdb/graph/AmberHistoryTransactionsSinceTest.java
@@ -168,10 +168,10 @@ public class AmberHistoryTransactionsSinceTest {
             p.setTitle("page " + (i+1));
             
             c1.setCopyRole(CopyRole.ACCESS_COPY.code());
-            f1.setBlobId(i);
+            f1.setBlobIdAndSize(i);
 
             c2.setCopyRole(CopyRole.OCR_JSON_COPY.code());
-            f2.setBlobId(i+100);
+            f2.setBlobIdAndSize(i+100);
         }
         aGraph.commit("test", "commit book");
 

--- a/test/amberdb/model/FileTest.java
+++ b/test/amberdb/model/FileTest.java
@@ -45,6 +45,16 @@ public class FileTest extends AbstractDatabaseIntegrationTest {
         assertEquals(4L, file.getFileSize());
         assertEquals(4L, file.getSize());
 
+        // replace file
+        file.put(Writables.wrap("TEXT5"));
+        assertEquals(5L, file.getFileSize());
+        assertEquals(5L, file.getSize());
+
+        // point to non-existent blob
+        file.setBlobIdAndSize(0L);
+        assertEquals(0L, file.getFileSize());
+        assertEquals(0L, file.getSize());
+
         copy = work.addCopy();
         file = copy.addFile();
         file.putLegacyDoss(Paths.get("test/resources/hello.txt"));


### PR DESCRIPTION
Modify the way getting a file's size works, so that if you use the getFileSize method it will populate the File vertex's fileSize attribute from the blob's reported size if the attribute is null. 

Modified the getSize method (which always tries to get the size from the blob before checking the attribute) so it doesn't call the getFileSize method (as that could call the blob's size method twice). 

I'm not keen on side effects like this change incorporates, but it prevents going to the blob every time you want to know the file's size when calling getFileSize because that can be an expensive/slow activity.

@ato @yetti @josephcurtis @jrixon @sjacob @snezanam @shuangzhou, basically 'at' everyone :-)  
