### PR TITLE
All vertices and edges now persist to the flat tables.

### DIFF
--- a/src/amberdb/graph/AmberEdge.java
+++ b/src/amberdb/graph/AmberEdge.java
@@ -132,4 +132,15 @@ public class AmberEdge extends BaseEdge implements Comparable {
 		return txnEnd;
 	}
 
+	public Long getInId() {
+		return inId;
+	}
+
+	public Long getOutId() {
+		return outId;
+	}
+
+	public Integer getOrder() {
+		return order;
+	}
 }

--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -211,6 +211,8 @@ public class AmberGraph extends BaseGraph
 
         dao.createIdGeneratorTable();
         dao.createTransactionTable();
+        
+        dao.createV2Tables();
        
         newId(); // seed generator with id > 0
     }
@@ -854,7 +856,7 @@ public class AmberGraph extends BaseGraph
                 dao.endWorks(txnId);
                 dao.endFiles(txnId);
                 dao.endTags(txnId);
-                dao.endPartys(txnId);
+                dao.endParties(txnId);
                 dao.endDescriptions(txnId);
                 dao.endFlatedges(txnId);
                 // start new elements for new and modified transaction elements
@@ -863,7 +865,7 @@ public class AmberGraph extends BaseGraph
                 dao.startWorks(txnId);
                 dao.startFiles(txnId);
                 dao.startTags(txnId);
-                dao.startPartys(txnId);
+                dao.startParties(txnId);
                 dao.startDescriptions(txnId);
                 dao.startFlatedges(txnId);
                 // Refactor note: need to check when adding (modding?) edges that both ends exist

--- a/src/amberdb/graph/AmberGraph.java
+++ b/src/amberdb/graph/AmberGraph.java
@@ -48,7 +48,42 @@ public class AmberGraph extends BaseGraph
     
     public static final DataSource DEFAULT_DATASOURCE = 
             JdbcConnectionPool.create("jdbc:h2:mem:persist","pers","pers");
+    
+    private static final Map<String, String>  vertexToTableMap = new HashMap<>();
+    static {
+    	vertexToTableMap.put("work",            "work");
+    	vertexToTableMap.put("eadwork",         "work");
+    	vertexToTableMap.put("page",            "work");
+    	vertexToTableMap.put("copy",            "work");
+    	vertexToTableMap.put("section",         "work");
+    	vertexToTableMap.put("file",            "file");
+    	vertexToTableMap.put("imagefile",       "file");
+    	vertexToTableMap.put("movingimagefile", "file");
+    	vertexToTableMap.put("soundfile",       "file");
+    	vertexToTableMap.put("description",     "description");
+    	vertexToTableMap.put("cameradata",      "description");
+    	vertexToTableMap.put("geocoding",       "description");
+    	vertexToTableMap.put("iptc",            "description");
+    	vertexToTableMap.put("party",           "party");
+    	vertexToTableMap.put("tag",             "tag");
+    }
 
+    private static final Map<String, String>  edgeToTableMap = new HashMap<>();
+    static {
+    	edgeToTableMap.put("label",          "flatedge");
+    	edgeToTableMap.put("acknowledge",    "flatedge");
+    	edgeToTableMap.put("deliveredOn",    "flatedge");
+    	edgeToTableMap.put("descriptionOf",  "flatedge");
+    	edgeToTableMap.put("existsOn",       "flatedge");
+    	edgeToTableMap.put("isCopyOf",       "flatedge");
+    	edgeToTableMap.put("isDerivativeOf", "flatedge");
+    	edgeToTableMap.put("isFileOf",       "flatedge");
+    	edgeToTableMap.put("isPartOf",       "flatedge");
+    	edgeToTableMap.put("represents",     "flatedge");
+    	edgeToTableMap.put("tags",           "flatedge");
+    }
+    
+    
     protected DBI dbi;
     private AmberDao dao;
 
@@ -817,10 +852,20 @@ public class AmberGraph extends BaseGraph
                 log.debug("ending elements");
                 dao.endElements(txnId);
                 dao.endWorks(txnId);
+                dao.endFiles(txnId);
+                dao.endTags(txnId);
+                dao.endPartys(txnId);
+                dao.endDescriptions(txnId);
+                dao.endFlatedges(txnId);
                 // start new elements for new and modified transaction elements
                 log.debug("starting elements");
                 dao.startElements(txnId);
                 dao.startWorks(txnId);
+                dao.startFiles(txnId);
+                dao.startTags(txnId);
+                dao.startPartys(txnId);
+                dao.startDescriptions(txnId);
+                dao.startFlatedges(txnId);
                 // Refactor note: need to check when adding (modding?) edges that both ends exist
                 dao.insertTransaction(txnId, new Date().getTime(), user, operation);
                 dao.commit();
@@ -838,7 +883,6 @@ public class AmberGraph extends BaseGraph
                         log.error("Backoff delay failed :", ie); // noted
                     }
                     backoff = backoff *2;
-                    dao.begin();
                 } else {
                     log.error("AmberDb commit failed after {} retries: Reason:", retries, e);
                     throw e;
@@ -1133,7 +1177,7 @@ public class AmberGraph extends BaseGraph
 	}
 
 	private void addEdge(Map<String, Set<AmberEdge>> edgesByType, AmberEdge e) {
-		final String type = e.getProperty("type");
+		final String type = e.getLabel();
 		if (StringUtils.isNotBlank(type)) {
 			Set<AmberEdge> set = edgesByType.get(type);
 			if (set == null) {
@@ -1146,13 +1190,21 @@ public class AmberGraph extends BaseGraph
 	
 	private void suspendIntoFlatVertexTables(Long sessId, Map<String, Set<AmberVertex>> verticesByType, String operation) {
         for (Entry<String, Set<AmberVertex>> entry: verticesByType.entrySet()) {
-        	dao.suspendIntoFlatVertexTable(sessId, operation, "sess_" + entry.getKey(), entry.getValue());
+        	String vertexType = entry.getKey().toLowerCase();
+        	String table = vertexToTableMap.get(vertexType);
+        	if (StringUtils.isNotBlank(table)) {
+        		dao.suspendIntoFlatVertexTable(sessId, operation, "sess_" + table, entry.getValue());
+        	}
         }
 	}
 
 	private void suspendIntoFlatEdgeTables(Long sessId, Map<String, Set<AmberEdge>> edgesByType, String operation) {
         for (Entry<String, Set<AmberEdge>> entry: edgesByType.entrySet()) {
-        	dao.suspendIntoFlatEdgeTable(sessId, operation, "sess_" + entry.getKey(), entry.getValue());
+        	String edgeType = entry.getKey().toLowerCase();
+        	String table = edgeToTableMap.get(edgeType);
+        	if (StringUtils.isNotBlank(table)) {
+        		dao.suspendIntoFlatEdgeTable(sessId, operation, "sess_" + table, entry.getValue());
+        	}
         }
 	}
 

--- a/src/amberdb/graph/dao/AmberDao.java
+++ b/src/amberdb/graph/dao/AmberDao.java
@@ -252,1910 +252,897 @@ public abstract class AmberDao implements Transactional<AmberDao>, GetHandle {
     public abstract void createSessionPropertyIdStateIndex();
 
     @SqlUpdate(
-        "CREATE TABLE cameradata" +
-        "(" +
-        "    id BIGINT(20)," +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    exposureTime VARCHAR(17), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    whiteBalance VARCHAR(18), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    lens VARCHAR(27), " +
-        "    title TEXT, " +
-        "    focalLenth VARCHAR(8), " +
-        "    holdingId VARCHAR(7), " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    isoSpeedRating VARCHAR(5), " +
-        "    recordSource VARCHAR(8), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    meteringMode VARCHAR(23), " +
-        "    creator TEXT, " +
-        "    coordinates TEXT, " +
-        "    fileSource VARCHAR(26), " +
-        "    otherTitle TEXT, " +
-        "    holdingNumber TEXT, " +
-        "    exposureProgram VARCHAR(19), " +
-        "    exposureFNumber VARCHAR(5), " +
-        "    publisher TEXT, " +
-        "    scaleEtc TEXT, " +
-        "    exposureMode VARCHAR(15), " +
-        "    focalLength VARCHAR(8) " +
-        "); " +
-        "CREATE INDEX cameradata_id ON cameradata (id); " +
-        "CREATE TABLE cameradata_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    exposureTime VARCHAR(17), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    whiteBalance VARCHAR(18), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    lens VARCHAR(27), " +
-        "    title TEXT, " +
-        "    focalLenth VARCHAR(8), " +
-        "    holdingId VARCHAR(7), " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    isoSpeedRating VARCHAR(5), " +
-        "    recordSource VARCHAR(8), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    meteringMode VARCHAR(23), " +
-        "    creator TEXT, " +
-        "    coordinates TEXT, " +
-        "    fileSource VARCHAR(26), " +
-        "    otherTitle TEXT, " +
-        "    holdingNumber TEXT, " +
-        "    exposureProgram VARCHAR(19), " +
-        "    exposureFNumber VARCHAR(5), " +
-        "    publisher TEXT, " +
-        "    scaleEtc TEXT, " +
-        "    exposureMode VARCHAR(15), " +
-        "    focalLength VARCHAR(8) " +
-        "); " +
-        "CREATE INDEX cameradata_history_id ON cameradata_history (id); " +
-        "CREATE INDEX cameradata_history_txn_id ON cameradata_history (id, txn_start, txn_end); " +
-        "CREATE TABLE copy " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    extent TEXT, " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    title TEXT, " +
-        "    holdingId VARCHAR(7), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    australianContent TINYINT(1), " +
-        "    dateCreated DATETIME, " +
-        "    contributor TEXT, " +
-        "    timedStatus VARCHAR(9), " +
-        "    copyType VARCHAR(9), " +
-        "    alias TEXT, " +
-        "    copyStatus VARCHAR(4), " +
-        "    copyRole VARCHAR(3), " +
-        "    manipulation TEXT, " +
-        "    recordSource VARCHAR(8), " +
-        "    algorithm VARCHAR(8), " +
-        "    bibId VARCHAR(9), " +
-        "    creator TEXT, " +
-        "    otherNumbers VARCHAR(2), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    materialType VARCHAR(12), " +
-        "    commentsExternal TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    classification TEXT, " +
-        "    currentVersion VARCHAR(3), " +
-        "    commentsInternal TEXT, " +
-        "    bestCopy VARCHAR(1), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    series TEXT, " +
-        "    publisher TEXT, " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    dcmCopyPid VARCHAR(37) " +
-        "); " +
-        "CREATE INDEX copy_id ON copy (id); " +
-        "CREATE TABLE copy_desc " +
-        "( " +
-        "    id BIGINT(20) PRIMARY KEY NOT NULL, " +
-        "    copy_id BIGINT(20), " +
-        "    created_at DATETIME, " +
-        "    created_by VARCHAR(200), " +
-        "    updated_at DATETIME, " +
-        "    updated_by VARCHAR(200), " +
-        "    exposure_program TEXT, " +
-        "    exposure_time TEXT, " +
-        "    focal_lenth TEXT, " +
-        "    iso_speed_rating TEXT, " +
-        "    lens TEXT, " +
-        "    metering_mode TEXT, " +
-        "    type TEXT, " +
-        "    exposure_mode TEXT, " +
-        "    white_balance TEXT, " +
-        "    exposure_fnumber TEXT, " +
-        "    file_source TEXT, " +
-        "    focal_length TEXT, " +
-        "    bib_id TEXT, " +
-        "    coordinates TEXT, " +
-        "    coverage TEXT, " +
-        "    encoding_level TEXT, " +
-        "    extent TEXT, " +
-        "    holding_id TEXT, " +
-        "    holding_number TEXT, " +
-        "    language TEXT, " +
-        "    local_system_number TEXT, " +
-        "    other_title TEXT, " +
-        "    publisher TEXT, " +
-        "    record_source TEXT, " +
-        "    scale_etc TEXT, " +
-        "    standard_id TEXT, " +
-        "    title TEXT " +
-        "); " +
-        "CREATE TABLE copy_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    extent TEXT, " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    title TEXT, " +
-        "    holdingId VARCHAR(7), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    australianContent TINYINT(1), " +
-        "    dateCreated DATETIME, " +
-        "    contributor TEXT, " +
-        "    timedStatus VARCHAR(9), " +
-        "    copyType VARCHAR(9), " +
-        "    alias TEXT, " +
-        "    copyStatus VARCHAR(4), " +
-        "    copyRole VARCHAR(3), " +
-        "    manipulation TEXT, " +
-        "    recordSource VARCHAR(8), " +
-        "    algorithm VARCHAR(8), " +
-        "    bibId VARCHAR(9), " +
-        "    creator TEXT, " +
-        "    otherNumbers VARCHAR(2), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    materialType VARCHAR(12), " +
-        "    commentsExternal TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    classification TEXT, " +
-        "    currentVersion VARCHAR(3), " +
-        "    commentsInternal TEXT, " +
-        "    bestCopy VARCHAR(1), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    series TEXT, " +
-        "    publisher TEXT, " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    dcmCopyPid VARCHAR(37) " +
-        "); " +
-        "CREATE INDEX copy_history_id ON copy_history (id); " +
-        "CREATE INDEX copy_history_txn_id ON copy_history (id, txn_start, txn_end); " +
-        "CREATE TABLE dup_edge_to_be_removed " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    v_out BIGINT(20), " +
-        "    v_in BIGINT(20), " +
-        "    label VARCHAR(100), " +
-        "    edge_order BIGINT(20) " +
-        "); " +
-        "CREATE TABLE dup_property_to_be_removed " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE dup_vertex_to_be_removed " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE durations " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    copy_id BIGINT(20), " +
-        "    role CHAR(5), " +
-        "    duration_secs BIGINT(20), " +
-        "    carrier VARCHAR(200) " +
-        "); " +
-        "CREATE TABLE eadfeature " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    records TEXT, " +
-        "    featureType VARCHAR(15), " +
-        "    fields VARCHAR(19), " +
-        "    featureId VARCHAR(39) " +
-        "); " +
-        "CREATE INDEX eadfeature_id ON eadfeature (id); " +
-        "CREATE TABLE eadfeature_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    records TEXT, " +
-        "    featureType VARCHAR(15), " +
-        "    fields VARCHAR(19), " +
-        "    featureId VARCHAR(39) " +
-        "); " +
-        "CREATE INDEX eadfeature_history_id ON eadfeature_history (id); " +
-        "CREATE INDEX eadfeature_history_txn_id ON eadfeature_history (id, txn_start, txn_end); " +
-        "CREATE TABLE eadwork " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    endDate DATETIME, " +
-        "    displayTitlePage TINYINT(1), " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    repository VARCHAR(30), " +
-        "    holdingId VARCHAR(7), " +
-        "    arrangement TEXT, " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    folderNumber TEXT, " +
-        "    collectionNumber VARCHAR(49), " +
-        "    west VARCHAR(1), " +
-        "    totalDuration VARCHAR(10), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    relatedMaterial TEXT, " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    otherTitle TEXT, " +
-        "    classification TEXT, " +
-        "    commentsInternal TEXT, " +
-        "    immutable VARCHAR(12), " +
-        "    folder TEXT, " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    nextStep VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    subType VARCHAR(7), " +
-        "    copyingPublishing TEXT, " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    tempHolding VARCHAR(2), " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    access TEXT, " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    isMissingPage TINYINT(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    north VARCHAR(1), " +
-        "    scopeContent TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    standardId TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    title TEXT, " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    australianContent TINYINT(1), " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    bibliography TEXT, " +
-        "    contributor TEXT, " +
-        "    provenance TEXT, " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    subUnitType VARCHAR(23), " +
-        "    rights TEXT, " +
-        "    uniformTitle TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    alias TEXT, " +
-        "    recordSource VARCHAR(8), " +
-        "    dateRangeInAS VARCHAR(9), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    summary TEXT, " +
-        "    creator TEXT, " +
-        "    preferredCitation TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    folderType VARCHAR(31), " +
-        "    bibLevel VARCHAR(9), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    form VARCHAR(19), " +
-        "    series TEXT, " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    constraint1 TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14) " +
-        "); " +
-        "CREATE INDEX eadwork_id ON eadwork (id); " +
-        "CREATE TABLE eadwork_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    endDate DATETIME, " +
-        "    displayTitlePage TINYINT(1), " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    repository VARCHAR(30), " +
-        "    holdingId VARCHAR(7), " +
-        "    arrangement TEXT, " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    folderNumber TEXT, " +
-        "    collectionNumber VARCHAR(49), " +
-        "    west VARCHAR(1), " +
-        "    totalDuration VARCHAR(10), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    relatedMaterial TEXT, " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    otherTitle TEXT, " +
-        "    classification TEXT, " +
-        "    commentsInternal TEXT, " +
-        "    immutable VARCHAR(12), " +
-        "    folder TEXT, " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    nextStep VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    subType VARCHAR(7), " +
-        "    copyingPublishing TEXT, " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    tempHolding VARCHAR(2), " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    access TEXT, " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    isMissingPage TINYINT(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    north VARCHAR(1), " +
-        "    scopeContent TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    standardId TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    title TEXT, " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    australianContent TINYINT(1), " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    bibliography TEXT, " +
-        "    contributor TEXT, " +
-        "    provenance TEXT, " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    subUnitType VARCHAR(23), " +
-        "    rights TEXT, " +
-        "    uniformTitle TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    alias TEXT, " +
-        "    recordSource VARCHAR(8), " +
-        "    dateRangeInAS VARCHAR(9), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    summary TEXT, " +
-        "    creator TEXT, " +
-        "    preferredCitation TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    folderType VARCHAR(31), " +
-        "    bibLevel VARCHAR(9), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    form VARCHAR(19), " +
-        "    series TEXT, " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    constraint1 TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14) " +
-        "); " +
-        "CREATE INDEX eadwork_history_id ON eadwork_history (id); " +
-        "CREATE INDEX eadwork_history_txn_id ON eadwork_history (id, txn_start, txn_end); " +
-        "CREATE TABLE file " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    fileName TEXT, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    software VARCHAR(33), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    mimeType TEXT, " +
-        "    title TEXT, " +
-        "    holdingId VARCHAR(7), " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    checksum VARCHAR(40), " +
-        "    recordSource VARCHAR(8), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    creator TEXT, " +
-        "    checksumGenerationDate DATETIME, " +
-        "    coordinates TEXT, " +
-        "    encoding VARCHAR(10), " +
-        "    holdingNumber TEXT, " +
-        "    fileSize BIGINT(20), " +
-        "    blobId BIGINT(20), " +
-        "    checksumType VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    compression VARCHAR(9), " +
-        "    device VARCHAR(44), " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX file_id ON file (id); " +
-        "CREATE TABLE file_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    fileName TEXT, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    software VARCHAR(33), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    standardId TEXT, " +
-        "    language VARCHAR(35), " +
-        "    mimeType TEXT, " +
-        "    title TEXT, " +
-        "    holdingId VARCHAR(7), " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    checksum VARCHAR(40), " +
-        "    recordSource VARCHAR(8), " +
-        "    coverage TEXT, " +
-        "    bibId VARCHAR(9), " +
-        "    creator TEXT, " +
-        "    checksumGenerationDate DATETIME, " +
-        "    coordinates TEXT, " +
-        "    encoding VARCHAR(10), " +
-        "    holdingNumber TEXT, " +
-        "    fileSize BIGINT(20), " +
-        "    blobId BIGINT(20), " +
-        "    checksumType VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    compression VARCHAR(9), " +
-        "    device VARCHAR(44), " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX file_history_id ON file_history (id); " +
-        "CREATE INDEX file_history_txn_id ON file_history (id, txn_start, txn_end); " +
-        "CREATE TABLE imagefile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    fileName TEXT, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    software VARCHAR(33), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    language VARCHAR(35), " +
-        "    mimeType TEXT, " +
-        "    resolution VARCHAR(37), " +
-        "    manufacturerSerialNumber VARCHAR(12), " +
-        "    holdingId VARCHAR(7), " +
-        "    resolutionUnit VARCHAR(4), " +
-        "    imageWidth INT(11), " +
-        "    manufacturerMake VARCHAR(27), " +
-        "    manufacturerModelName VARCHAR(41), " +
-        "    encoding VARCHAR(10), " +
-        "    deviceSerialNumber VARCHAR(20), " +
-        "    fileSize BIGINT(20), " +
-        "    bitDepth VARCHAR(8), " +
-        "    publisher TEXT, " +
-        "    compression VARCHAR(9), " +
-        "    device VARCHAR(44), " +
-        "    imageLength INT(11), " +
-        "    colourSpace VARCHAR(15), " +
-        "    standardId TEXT, " +
-        "    title TEXT, " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    checksum VARCHAR(40), " +
-        "    recordSource VARCHAR(8), " +
-        "    bibId VARCHAR(9), " +
-        "    coverage TEXT, " +
-        "    orientation VARCHAR(36), " +
-        "    creator TEXT, " +
-        "    colourProfile VARCHAR(9), " +
-        "    checksumGenerationDate DATETIME, " +
-        "    applicationDateCreated VARCHAR(19), " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    fileFormatVersion VARCHAR(3), " +
-        "    dateDigitised VARCHAR(19), " +
-        "    holdingNumber TEXT, " +
-        "    application TEXT, " +
-        "    series TEXT, " +
-        "    blobId BIGINT(20), " +
-        "    softwareSerialNumber VARCHAR(10), " +
-        "    checksumType VARCHAR(4), " +
-        "    location TEXT, " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX imagefile_id ON imagefile (id); " +
-        "CREATE TABLE imagefile_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    fileName TEXT, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    software VARCHAR(33), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    language VARCHAR(35), " +
-        "    mimeType TEXT, " +
-        "    resolution VARCHAR(37), " +
-        "    manufacturerSerialNumber VARCHAR(12), " +
-        "    holdingId VARCHAR(7), " +
-        "    resolutionUnit VARCHAR(4), " +
-        "    imageWidth INT(11), " +
-        "    manufacturerMake VARCHAR(27), " +
-        "    manufacturerModelName VARCHAR(41), " +
-        "    encoding VARCHAR(10), " +
-        "    deviceSerialNumber VARCHAR(20), " +
-        "    fileSize BIGINT(20), " +
-        "    bitDepth VARCHAR(8), " +
-        "    publisher TEXT, " +
-        "    compression VARCHAR(9), " +
-        "    device VARCHAR(44), " +
-        "    imageLength INT(11), " +
-        "    colourSpace VARCHAR(15), " +
-        "    standardId TEXT, " +
-        "    title TEXT, " +
-        "    australianContent TINYINT(1), " +
-        "    contributor TEXT, " +
-        "    checksum VARCHAR(40), " +
-        "    recordSource VARCHAR(8), " +
-        "    bibId VARCHAR(9), " +
-        "    coverage TEXT, " +
-        "    orientation VARCHAR(36), " +
-        "    creator TEXT, " +
-        "    colourProfile VARCHAR(9), " +
-        "    checksumGenerationDate DATETIME, " +
-        "    applicationDateCreated VARCHAR(19), " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    fileFormatVersion VARCHAR(3), " +
-        "    dateDigitised VARCHAR(19), " +
-        "    holdingNumber TEXT, " +
-        "    application TEXT, " +
-        "    series TEXT, " +
-        "    blobId BIGINT(20), " +
-        "    softwareSerialNumber VARCHAR(10), " +
-        "    checksumType VARCHAR(4), " +
-        "    location TEXT, " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX imagefile_history_id ON imagefile_history (id); " +
-        "CREATE INDEX imagefile_history_txn_id ON imagefile_history (id, txn_start, txn_end); " +
-        "CREATE TABLE indexed_txns " +
-        "( " +
-        "    txn BIGINT(11) " +
-        "); " +
-        "CREATE INDEX indexed_txns_idx ON indexed_txns (txn); " +
-        "CREATE TABLE list " +
-        "( " +
-        "    name VARCHAR(100), " +
-        "    value VARCHAR(100), " +
-        "    deleted VARCHAR(1) " +
-        "); " +
-        "CREATE TABLE page " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    extent TEXT, " +
-        "    notes VARCHAR(30), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    encodingLevel VARCHAR(47), " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    displayTitlePage TINYINT(1), " +
-        "    endDate DATETIME, " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    vendorId VARCHAR(7), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    repository VARCHAR(30), " +
-        "    holdingId VARCHAR(7), " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    west VARCHAR(1), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    commentsExternal TEXT, " +
-        "    firstPart VARCHAR(27), " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    otherTitle TEXT, " +
-        "    classification TEXT, " +
-        "    localSystemno VARCHAR(7), " +
-        "    commentsInternal TEXT, " +
-        "    acquisitionStatus VARCHAR(7), " +
-        "    immutable VARCHAR(12), " +
-        "    restrictionType VARCHAR(0), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    ilmsSentDateTime DATETIME, " +
-        "    publisher TEXT, " +
-        "    nextStep VARCHAR(4), " +
-        "    subType VARCHAR(7), " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    tempHolding VARCHAR(2), " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    tilePosition TEXT, " +
-        "    sortIndex VARCHAR(28), " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    isMissingPage TINYINT(1), " +
-        "    north VARCHAR(1), " +
-        "    standardId TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    scopeContent TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    edition TEXT, " +
-        "    alternativeTitle VARCHAR(20), " +
-        "    title TEXT, " +
-        "    acquisitionCategory VARCHAR(19), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    australianContent TINYINT(1), " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    contributor TEXT, " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    subUnitType VARCHAR(23), " +
-        "    uniformTitle TEXT, " +
-        "    rights TEXT, " +
-        "    alias TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    issueDate DATETIME, " +
-        "    recordSource VARCHAR(8), " +
-        "    bibId VARCHAR(16), " +
-        "    coverage TEXT, " +
-        "    summary TEXT, " +
-        "    creator TEXT, " +
-        "    sensitiveReason TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    interactiveIndexAvailable TINYINT(1), " +
-        "    bibLevel VARCHAR(9), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    form VARCHAR(19), " +
-        "    series TEXT, " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    constraint1 TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    depositType TEXT, " +
-        "    parentConstraint VARCHAR(35) " +
-        "); " +
-        "CREATE INDEX page_id ON page (id); " +
-        "CREATE TABLE page_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    extent TEXT, " +
-        "    notes VARCHAR(30), " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    encodingLevel VARCHAR(47), " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    displayTitlePage TINYINT(1), " +
-        "    endDate DATETIME, " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    vendorId VARCHAR(7), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    repository VARCHAR(30), " +
-        "    holdingId VARCHAR(7), " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    west VARCHAR(1), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    commentsExternal TEXT, " +
-        "    firstPart VARCHAR(27), " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    otherTitle TEXT, " +
-        "    classification TEXT, " +
-        "    localSystemno VARCHAR(7), " +
-        "    commentsInternal TEXT, " +
-        "    acquisitionStatus VARCHAR(7), " +
-        "    immutable VARCHAR(12), " +
-        "    restrictionType VARCHAR(0), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    ilmsSentDateTime DATETIME, " +
-        "    publisher TEXT, " +
-        "    nextStep VARCHAR(4), " +
-        "    subType VARCHAR(7), " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    tempHolding VARCHAR(2), " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    tilePosition TEXT, " +
-        "    sortIndex VARCHAR(28), " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    isMissingPage TINYINT(1), " +
-        "    north VARCHAR(1), " +
-        "    standardId TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    scopeContent TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    edition TEXT, " +
-        "    alternativeTitle VARCHAR(20), " +
-        "    title TEXT, " +
-        "    acquisitionCategory VARCHAR(19), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    australianContent TINYINT(1), " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    contributor TEXT, " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    subUnitType VARCHAR(23), " +
-        "    uniformTitle TEXT, " +
-        "    rights TEXT, " +
-        "    alias TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    issueDate DATETIME, " +
-        "    recordSource VARCHAR(8), " +
-        "    bibId VARCHAR(16), " +
-        "    coverage TEXT, " +
-        "    summary TEXT, " +
-        "    creator TEXT, " +
-        "    sensitiveReason TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    interactiveIndexAvailable TINYINT(1), " +
-        "    bibLevel VARCHAR(9), " +
-        "    carrier VARCHAR(17), " +
-        "    holdingNumber TEXT, " +
-        "    form VARCHAR(19), " +
-        "    series TEXT, " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    constraint1 TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    depositType TEXT, " +
-        "    parentConstraint VARCHAR(35) " +
-        "); " +
-        "CREATE INDEX page_history_id ON page_history (id); " +
-        "CREATE INDEX page_history_txn_id ON page_history (id, txn_start, txn_end); " +
-        "CREATE TABLE party_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    name VARCHAR(47), " +
-        "    suppressed TINYINT(1), " +
-        "    orgUrl TEXT, " +
-        "    logoUrl VARCHAR(17) " +
-        "); " +
-        "CREATE INDEX party_history_id ON party_history (id); " +
-        "CREATE INDEX party_history_txn_id ON party_history (id, txn_start, txn_end); " +
-        "CREATE TABLE property_all_cameradata " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_cameradata_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_cameradata_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_copy " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_copy_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_copy_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_eadfeature " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_eadfeature_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_eadfeature_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_eadwork " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_eadwork_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_eadwork_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_file " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_file_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_file_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_geocoding " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_geocoding_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_geocoding_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_imagefile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_imagefile_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_imagefile_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_iptc " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_iptc_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_iptc_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_page " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_page_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_page_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_party " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_party_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_party_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_section " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_section_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_section_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_soundfile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_soundfile_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_soundfile_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_tag " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_tag_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_tag_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_work " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE property_all_work_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_all_work_txns " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_cameradata " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_cameradata_type ON property_current_cameradata (name); " +
-        "CREATE TABLE property_current_cameradata_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_copy " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_copy_type ON property_current_copy (name); " +
-        "CREATE TABLE property_current_copy_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_eadfeature " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_eadfeature_type ON property_current_eadfeature (name); " +
-        "CREATE TABLE property_current_eadfeature_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_eadwork " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_eadwork_type ON property_current_eadwork (name); " +
-        "CREATE TABLE property_current_eadwork_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_file " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_file_type ON property_current_file (name); " +
-        "CREATE TABLE property_current_file_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_geocoding " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_geocoding_type ON property_current_geocoding (name); " +
-        "CREATE TABLE property_current_geocoding_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_imagefile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_imagefile_type ON property_current_imagefile (name); " +
-        "CREATE TABLE property_current_imagefile_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_iptc " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_iptc_type ON property_current_iptc (name); " +
-        "CREATE TABLE property_current_iptc_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_page " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_page_type ON property_current_page (name); " +
-        "CREATE TABLE property_current_page_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_party " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_party_type ON property_current_party (name); " +
-        "CREATE TABLE property_current_party_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_section " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_section_type ON property_current_section (name); " +
-        "CREATE TABLE property_current_section_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_soundfile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_soundfile_type ON property_current_soundfile (name); " +
-        "CREATE TABLE property_current_soundfile_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_tag " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_tag_type ON property_current_tag (name); " +
-        "CREATE TABLE property_current_tag_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE property_current_work " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE INDEX property_current_work_type ON property_current_work (name); " +
-        "CREATE TABLE property_current_work_ids " +
-        "( " +
-        "    id BIGINT(20) " +
-        "); " +
-        "CREATE TABLE restrictions_on_access " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    value TEXT " +
-        "); " +
-        "CREATE TABLE section " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    creator TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    abstract TEXT, " +
-        "    advertising TINYINT(1), " +
-        "    title TEXT, " +
-        "    printedPageNumber VARCHAR(14), " +
-        "    captions VARCHAR(255), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    bibLevel VARCHAR(9), " +
-        "    illustrated TINYINT(1), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    metsId VARCHAR(8), " +
-        "    subType VARCHAR(7), " +
-        "    constraint1 TEXT " +
-        "); " +
-        "CREATE INDEX section_id ON section (id); " +
-        "CREATE TABLE section_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    creator TEXT, " +
-        "    accessConditions VARCHAR(13), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    abstract TEXT, " +
-        "    advertising TINYINT(1), " +
-        "    title TEXT, " +
-        "    printedPageNumber VARCHAR(14), " +
-        "    captions VARCHAR(255), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    bibLevel VARCHAR(9), " +
-        "    illustrated TINYINT(1), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    metsId VARCHAR(8), " +
-        "    subType VARCHAR(7), " +
-        "    constraint1 TEXT " +
-        "); " +
-        "CREATE INDEX section_history_id ON section_history (id); " +
-        "CREATE INDEX section_history_txn_id ON section_history (id, txn_start, txn_end); " +
-        "CREATE TABLE series " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    value TEXT " +
-        "); " +
-        "CREATE TABLE soundfile " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    fileName TEXT, " +
-        "    software VARCHAR(33), " +
-        "    thickness VARCHAR(11), " +
-        "    channel VARCHAR(3), " +
-        "    bitrate VARCHAR(3), " +
-        "    mimeType TEXT, " +
-        "    durationType VARCHAR(7), " +
-        "    speed VARCHAR(10), " +
-        "    duration VARCHAR(12), " +
-        "    toolId VARCHAR(13), " +
-        "    checksum VARCHAR(40), " +
-        "    soundField VARCHAR(9), " +
-        "    fileContainer VARCHAR(3), " +
-        "    brand VARCHAR(27), " +
-        "    surface VARCHAR(20), " +
-        "    equalisation VARCHAR(4), " +
-        "    encoding VARCHAR(10), " +
-        "    codec VARCHAR(4), " +
-        "    fileSize BIGINT(20), " +
-        "    reelSize VARCHAR(12), " +
-        "    carrierCapacity VARCHAR(7), " +
-        "    bitDepth VARCHAR(8), " +
-        "    blobId BIGINT(20), " +
-        "    checksumType VARCHAR(4), " +
-        "    samplingRate VARCHAR(5), " +
-        "    compression VARCHAR(9), " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX soundfile_id ON soundfile (id); " +
-        "CREATE TABLE soundfile_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    fileName TEXT, " +
-        "    software VARCHAR(33), " +
-        "    thickness VARCHAR(11), " +
-        "    channel VARCHAR(3), " +
-        "    bitrate VARCHAR(3), " +
-        "    mimeType TEXT, " +
-        "    durationType VARCHAR(7), " +
-        "    speed VARCHAR(10), " +
-        "    duration VARCHAR(12), " +
-        "    toolId VARCHAR(13), " +
-        "    checksum VARCHAR(40), " +
-        "    soundField VARCHAR(9), " +
-        "    fileContainer VARCHAR(3), " +
-        "    brand VARCHAR(27), " +
-        "    surface VARCHAR(20), " +
-        "    equalisation VARCHAR(4), " +
-        "    encoding VARCHAR(10), " +
-        "    codec VARCHAR(4), " +
-        "    fileSize BIGINT(20), " +
-        "    reelSize VARCHAR(12), " +
-        "    carrierCapacity VARCHAR(7), " +
-        "    bitDepth VARCHAR(8), " +
-        "    blobId BIGINT(20), " +
-        "    checksumType VARCHAR(4), " +
-        "    samplingRate VARCHAR(5), " +
-        "    compression VARCHAR(9), " +
-        "    fileFormat VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX soundfile_history_id ON soundfile_history (id); " +
-        "CREATE INDEX soundfile_history_txn_id ON soundfile_history (id, txn_start, txn_end); " +
-        "CREATE TABLE stage_edge " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_new BIGINT(20), " +
-        "    v_out BIGINT(20), " +
-        "    v_in BIGINT(20), " +
-        "    label VARCHAR(100), " +
-        "    edge_order BIGINT(20), " +
-        "    state CHAR(3) " +
-        "); " +
-        "CREATE INDEX stage_edge_combined_state_new_idx ON stage_edge (txn_new, state); " +
-        "CREATE INDEX stage_edge_id_idx ON stage_edge (id); " +
-        "CREATE INDEX stage_edge_stage_idx ON stage_edge (state); " +
-        "CREATE INDEX stage_edge_txn_new_idx ON stage_edge (txn_new); " +
-        "CREATE TABLE stage_property " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_new BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE stage_vertex " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_new BIGINT(20), " +
-        "    state CHAR(3) " +
-        "); " +
-        "CREATE INDEX stage_vertex_combined_state_new_idx ON stage_vertex (txn_new, state); " +
-        "CREATE INDEX stage_vertex_combined_txn_new_state_idx ON stage_vertex (txn_new, state); " +
-        "CREATE TABLE tag " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    name VARCHAR(47) " +
-        "); " +
-        "CREATE INDEX tag_id ON tag (id); " +
-        "CREATE TABLE tag_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    name VARCHAR(47) " +
-        "); " +
-        "CREATE INDEX tag_history_id ON tag_history (id); " +
-        "CREATE INDEX tag_history_txn_id ON tag_history (id, txn_start, txn_end); " +
-        "CREATE TABLE work " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    endDate DATETIME, " +
-        "    displayTitlePage TINYINT(1), " +
-        "    holdingId VARCHAR(7), " +
-        "    hasRepresentation VARCHAR(1), " +
-        "    totalDuration VARCHAR(10), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    firstPart VARCHAR(27), " +
-        "    additionalTitle TEXT, " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    classification TEXT, " +
-        "    commentsInternal TEXT, " +
-        "    restrictionType VARCHAR(0), " +
-        "    ilmsSentDateTime DATETIME, " +
-        "    subType VARCHAR(7), " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    tilePosition TEXT, " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    preservicaType TEXT, " +
-        "    north VARCHAR(1), " +
-        "    accessConditions VARCHAR(13), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    australianContent TINYINT(1), " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    rights TEXT, " +
-        "    genre VARCHAR(11), " +
-        "    deliveryUrl VARCHAR(25), " +
-        "    recordSource VARCHAR(8), " +
-        "    sheetCreationDate TEXT, " +
-        "    creator TEXT, " +
-        "    sheetName TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    additionalCreator TEXT, " +
-        "    folderType VARCHAR(31), " +
-        "    eventNote TEXT, " +
-        "    interactiveIndexAvailable TINYINT(1), " +
-        "    startChild VARCHAR(17), " +
-        "    bibLevel VARCHAR(9), " +
-        "    holdingNumber TEXT, " +
-        "    publicNotes TEXT, " +
-        "    series TEXT, " +
-        "    constraint1 TEXT, " +
-        "    notes VARCHAR(30), " +
-        "    catalogueUrl VARCHAR(35), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    vendorId VARCHAR(7), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    folderNumber VARCHAR(50), " +
-        "    west VARCHAR(1), " +
-        "    html TEXT, " +
-        "    preservicaId TEXT, " +
-        "    redocworksReason VARCHAR(20), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    author TEXT, " +
-        "    commentsExternal TEXT, " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    otherTitle TEXT, " +
-        "    imageServerUrl VARCHAR(48), " +
-        "    localSystemno VARCHAR(7), " +
-        "    acquisitionStatus VARCHAR(7), " +
-        "    reorderType VARCHAR(8), " +
-        "    immutable VARCHAR(12), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    nextStep VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    additionalSeries TEXT, " +
-        "    tempHolding VARCHAR(2), " +
-        "    sortIndex VARCHAR(28), " +
-        "    isMissingPage TINYINT(1), " +
-        "    standardId TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    edition TEXT, " +
-        "    reorder VARCHAR(1), " +
-        "    title TEXT, " +
-        "    acquisitionCategory VARCHAR(19), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    contributor TEXT, " +
-        "    publicationCategory VARCHAR(11), " +
-        "    ingestJobId BIGINT(20), " +
-        "    subUnitType VARCHAR(23), " +
-        "    uniformTitle TEXT, " +
-        "    alias TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    issueDate DATETIME, " +
-        "    bibId VARCHAR(9), " +
-        "    coverage TEXT, " +
-        "    summary TEXT, " +
-        "    additionalContributor TEXT, " +
-        "    sendToIlmsDateTime VARCHAR(10), " +
-        "    sensitiveReason TEXT, " +
-        "    carrier VARCHAR(17), " +
-        "    form VARCHAR(19), " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    sprightlyUrl VARCHAR(39), " +
-        "    depositType TEXT, " +
-        "    parentConstraint VARCHAR(35), " +
-        "    additionalSeriesStatement TEXT " +
-        "); " +
-        "CREATE INDEX work_id ON work (id); " +
-        "CREATE TABLE work_902502_backup " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    type CHAR(3), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE work_desc " +
-        "( " +
-        "    id BIGINT(20) PRIMARY KEY NOT NULL, " +
-        "    work_id BIGINT(20), " +
-        "    created_at DATETIME, " +
-        "    created_by VARCHAR(200), " +
-        "    updated_at DATETIME, " +
-        "    updated_by VARCHAR(200), " +
-        "    feature_id TEXT, " +
-        "    feature_type TEXT, " +
-        "    fields TEXT, " +
-        "    records TEXT, " +
-        "    type TEXT, " +
-        "    latitude TEXT, " +
-        "    longitude TEXT, " +
-        "    map_datum TEXT, " +
-        "    timestamp DATETIME, " +
-        "    city TEXT, " +
-        "    province TEXT " +
-        "); " +
-        "CREATE TABLE work_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    extent TEXT, " +
-        "    dcmDateTimeUpdated DATETIME, " +
-        "    localSystemNumber VARCHAR(39), " +
-        "    occupation TEXT, " +
-        "    endDate DATETIME, " +
-        "    displayTitlePage TINYINT(1), " +
-        "    holdingId VARCHAR(7), " +
-        "    hasRepresentation VARCHAR(1), " +
-        "    totalDuration VARCHAR(10), " +
-        "    dcmDateTimeCreated DATETIME, " +
-        "    firstPart VARCHAR(27), " +
-        "    additionalTitle TEXT, " +
-        "    dcmWorkPid VARCHAR(31), " +
-        "    classification TEXT, " +
-        "    commentsInternal TEXT, " +
-        "    restrictionType VARCHAR(0), " +
-        "    ilmsSentDateTime DATETIME, " +
-        "    subType VARCHAR(7), " +
-        "    scaleEtc TEXT, " +
-        "    startDate DATETIME, " +
-        "    dcmRecordUpdater VARCHAR(26), " +
-        "    tilePosition TEXT, " +
-        "    allowHighResdownload TINYINT(1), " +
-        "    south VARCHAR(1), " +
-        "    restrictionsOnAccess TEXT, " +
-        "    preservicaType TEXT, " +
-        "    north VARCHAR(1), " +
-        "    accessConditions VARCHAR(13), " +
-        "    internalAccessConditions VARCHAR(10), " +
-        "    eadUpdateReviewRequired VARCHAR(1), " +
-        "    australianContent TINYINT(1), " +
-        "    moreIlmsDetailsRequired TINYINT(1), " +
-        "    rights TEXT, " +
-        "    genre VARCHAR(11), " +
-        "    deliveryUrl VARCHAR(25), " +
-        "    recordSource VARCHAR(8), " +
-        "    sheetCreationDate TEXT, " +
-        "    creator TEXT, " +
-        "    sheetName TEXT, " +
-        "    coordinates TEXT, " +
-        "    creatorStatement TEXT, " +
-        "    additionalCreator TEXT, " +
-        "    folderType VARCHAR(31), " +
-        "    eventNote TEXT, " +
-        "    interactiveIndexAvailable TINYINT(1), " +
-        "    startChild VARCHAR(17), " +
-        "    bibLevel VARCHAR(9), " +
-        "    holdingNumber TEXT, " +
-        "    publicNotes TEXT, " +
-        "    series TEXT, " +
-        "    constraint1 TEXT, " +
-        "    notes VARCHAR(30), " +
-        "    catalogueUrl VARCHAR(35), " +
-        "    encodingLevel VARCHAR(47), " +
-        "    materialFromMultipleSources TINYINT(1), " +
-        "    subject TEXT, " +
-        "    sendToIlms TINYINT(1), " +
-        "    vendorId VARCHAR(7), " +
-        "    allowOnsiteAccess TINYINT(1), " +
-        "    language VARCHAR(35), " +
-        "    sensitiveMaterial VARCHAR(3), " +
-        "    dcmAltPi VARCHAR(52), " +
-        "    folderNumber VARCHAR(50), " +
-        "    west VARCHAR(1), " +
-        "    html TEXT, " +
-        "    preservicaId TEXT, " +
-        "    redocworksReason VARCHAR(20), " +
-        "    workCreatedDuringMigration TINYINT(1), " +
-        "    author TEXT, " +
-        "    commentsExternal TEXT, " +
-        "    findingAidNote TEXT, " +
-        "    collection VARCHAR(7), " +
-        "    otherTitle TEXT, " +
-        "    imageServerUrl VARCHAR(48), " +
-        "    localSystemno VARCHAR(7), " +
-        "    acquisitionStatus VARCHAR(7), " +
-        "    reorderType VARCHAR(8), " +
-        "    immutable VARCHAR(12), " +
-        "    copyrightPolicy VARCHAR(31), " +
-        "    nextStep VARCHAR(4), " +
-        "    publisher TEXT, " +
-        "    additionalSeries TEXT, " +
-        "    tempHolding VARCHAR(2), " +
-        "    sortIndex VARCHAR(28), " +
-        "    isMissingPage TINYINT(1), " +
-        "    standardId TEXT, " +
-        "    representativeId VARCHAR(26), " +
-        "    edition TEXT, " +
-        "    reorder VARCHAR(1), " +
-        "    title TEXT, " +
-        "    acquisitionCategory VARCHAR(19), " +
-        "    subUnitNo TEXT, " +
-        "    expiryDate DATETIME, " +
-        "    digitalStatusDate DATETIME, " +
-        "    east VARCHAR(1), " +
-        "    contributor TEXT, " +
-        "    publicationCategory VARCHAR(11), " +
-        "    ingestJobId BIGINT(20), " +
-        "    subUnitType VARCHAR(23), " +
-        "    uniformTitle TEXT, " +
-        "    alias TEXT, " +
-        "    rdsAcknowledgementType VARCHAR(7), " +
-        "    issueDate DATETIME, " +
-        "    bibId VARCHAR(32), " +
-        "    coverage TEXT, " +
-        "    summary TEXT, " +
-        "    additionalContributor TEXT, " +
-        "    sendToIlmsDateTime VARCHAR(10), " +
-        "    sensitiveReason TEXT, " +
-        "    carrier VARCHAR(17), " +
-        "    form VARCHAR(19), " +
-        "    rdsAcknowledgementReceiver TEXT, " +
-        "    digitalStatus VARCHAR(18), " +
-        "    dcmRecordCreator VARCHAR(14), " +
-        "    sprightlyUrl VARCHAR(39), " +
-        "    depositType TEXT, " +
-        "    parentConstraint VARCHAR(35) " +
-        "); " +
-        "CREATE INDEX work_history_id ON work_history (id); " +
-        "CREATE INDEX work_history_txn_id ON work_history (id, txn_start, txn_end); " +
-        "CREATE TABLE work_copy " +
-        "( " +
-        "    work_id BIGINT(20) NOT NULL, " +
-        "    copy_id BIGINT(20) NOT NULL, " +
-        "    edge_order INT(11) NOT NULL, " +
-        "    work_type VARCHAR(20) NOT NULL, " +
-        "    copy_role VARCHAR(3) NOT NULL " +
-        "); " +
-        "CREATE INDEX wc_copy_id_index ON work_copy (copy_id); " +
-        "CREATE INDEX wc_edge_order_index ON work_copy (edge_order); " +
-        "CREATE INDEX wc_work_id_index ON work_copy (work_id); " +
-        "CREATE INDEX wc_work_id_type_index ON work_copy (work_id, work_type); " +
-        "CREATE TABLE copy_file " +
-        "( " +
-        "    copy_id BIGINT(20) NOT NULL, " +
-        "    file_id BIGINT(20) NOT NULL, " +
-        "    file_type VARCHAR(20) NOT NULL " +
-        "); " +
-        "CREATE INDEX cf_copy_id_file_type_index ON copy_file (copy_id, file_type); " +
-        "CREATE INDEX cf_copy_id_index ON copy_file (copy_id); " +
-        "CREATE INDEX cf_file_id_type_index ON copy_file (file_id, file_type); " +
-        "CREATE TABLE work_deliverywork " +
-        "( " +
-        "    work_id BIGINT(20) NOT NULL, " +
-        "    deliverywork_id BIGINT(20) NOT NULL, " +
-        "    edge_order INT(11) NOT NULL " +
-        "); " +
-        "CREATE INDEX wd_deliverywork_id_work_id_index ON work_deliverywork (deliverywork_id, work_id); " +
-        "CREATE INDEX wd_work_id_edge_order_index ON work_deliverywork (work_id, edge_order); " +
-        "CREATE INDEX wd_work_id_index ON work_deliverywork (work_id); " +
-        "CREATE TABLE work_section " +
-        "( " +
-        "    work_id BIGINT(20) NOT NULL, " +
-        "    section_id BIGINT(20) NOT NULL, " +
-        "    subtype VARCHAR(10) NOT NULL " +
-        "); " +
-        "CREATE INDEX ws_section_id_index ON work_section (section_id); " +
-        "CREATE INDEX ws_work_id_index ON work_section (work_id); " +
-        "CREATE INDEX ws_work_id_subtype_index ON work_section (work_id, subtype); " +
-        "CREATE TABLE parent_child " +
-        "( " +
-        "    parent_id BIGINT(20) NOT NULL, " +
-        "    child_id BIGINT(20) NOT NULL, " +
-        "    child_biblevel VARCHAR(10) NOT NULL, " +
-        "    child_subtype VARCHAR(10) NOT NULL " +
-        "); " +
-        "CREATE INDEX pc_child_id_biblevel_subtype ON parent_child (child_id, child_biblevel, child_subtype); " +
-        "CREATE INDEX pc_child_id_index ON parent_child (child_id); " +
-        "CREATE INDEX pc_parent_id_child_biblevel_subtype ON parent_child (parent_id, child_biblevel, child_subtype); " +
-        "CREATE INDEX pc_parent_id_index ON parent_child (parent_id); " +
-        "CREATE TABLE work_alias " +
-        "( " +
-        "    work_id BIGINT(20) NOT NULL, " +
-        "    alias VARCHAR(100) NOT NULL " +
-        "); " +
-        "CREATE INDEX wa_alias_work_id_index ON work_alias (alias, work_id); " +
-        "CREATE INDEX wa_work_id_index ON work_alias (work_id); " +
-        "CREATE TABLE party " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    name VARCHAR(47), " +
-        "    suppressed TINYINT(1), " +
-        "    orgUrl TEXT, " +
-        "    logoUrl VARCHAR(17) " +
-        "); " +
-        "CREATE TABLE temp_ack " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE temp_ack_history " +
-        "( " +
-        "    id BIGINT(20), " +
-        "    txn_start BIGINT(20), " +
-        "    txn_end BIGINT(20), " +
-        "    name VARCHAR(100), " +
-        "    value BLOB " +
-        "); " +
-        "CREATE TABLE acknowledgement_history " +
-        "( " +
-        "    id BIGINT(20) NOT NULL, " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    ack_type VARCHAR(100) DEFAULT '' NOT NULL, " +
-        "    kind_of_support VARCHAR(100) DEFAULT '' NOT NULL, " +
-        "    weighting DECIMAL(5,2) DEFAULT '0.00' NOT NULL, " +
-        "    url_to_original TEXT, " +
-        "    date DATETIME " +
-        "); " +
-        "CREATE INDEX ack_history_id_index ON acknowledgement_history (id); " +
-        "CREATE INDEX ack_history_id_weighting_index ON acknowledgement_history (id, weighting); " +
-        "CREATE TABLE acknowledgement " +
-        "( " +
-        "    id BIGINT(20) NOT NULL, " +
-        "    txn_start BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    txn_end BIGINT(20) DEFAULT '0' NOT NULL, " +
-        "    ack_type VARCHAR(100) DEFAULT '' NOT NULL, " +
-        "    kind_of_support VARCHAR(100) DEFAULT '' NOT NULL, " +
-        "    weighting DECIMAL(5,2) DEFAULT '0.00' NOT NULL, " +
-        "    url_to_original TEXT, " +
-        "    date DATETIME " +
-        "); " +
-        "CREATE INDEX ack_id_index ON acknowledgement (id); " +
-        "CREATE INDEX ack_id_weighting_index ON acknowledgement (id, weighting); " +
-        "CREATE TABLE acknowledgement_party " +
-        "( " +
-        "    acknowledgement_id BIGINT(20) NOT NULL, " +
-        "    party_id BIGINT(20) " +
-        "); " +
-        "CREATE INDEX ap_acknowledgement_id_index ON acknowledgement_party (acknowledgement_id); " +
-        "CREATE INDEX ap_party_id_index ON acknowledgement_party (party_id); " +
-        "CREATE TABLE work_acknowledgement " +
-        "( " +
-        "    work_id BIGINT(20), " +
-        "    acknowledgement_id BIGINT(20) NOT NULL, " +
-        "    weighting DECIMAL(5,2) DEFAULT '0.00' NOT NULL " +
-        "); " +
-        "CREATE INDEX wack_ack_id_index ON work_acknowledgement (acknowledgement_id); " +
-        "CREATE INDEX wack_ack_id_weighting_index ON work_acknowledgement (acknowledgement_id, weighting); " +
-        "CREATE INDEX wack_work_id_index ON work_acknowledgement (work_id); " +
-        "CREATE TABLE representative_work " +
-        "( " +
-        "    copy_id BIGINT(20), " +
-        "    work_id BIGINT(20), " +
-        "    edge_order INT(11), " +
-        "    work_type VARCHAR(20) " +
-        "); " +
-        "CREATE INDEX rw_copy_id_index ON representative_work (copy_id); " +
-        "CREATE INDEX rw_copy_id_order ON representative_work (copy_id, edge_order); " +
-        "CREATE INDEX rw_work_id_type_index ON representative_work (work_id, work_type);")
+    		         "DROP TABLE IF EXISTS work; "
+    				+"CREATE TABLE IF NOT EXISTS work ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" abstract TEXT, "
+    				+" access TEXT, "
+    				+" accessConditions VARCHAR(13), "
+    				+" acquisitionCategory VARCHAR(19), "
+    				+" acquisitionStatus VARCHAR(7), "
+    				+" additionalContributor TEXT, "
+    				+" additionalCreator TEXT, "
+    				+" additionalSeries TEXT, "
+    				+" additionalSeriesStatement VARCHAR(42), "
+    				+" additionalTitle TEXT, "
+    				+" addressee TEXT, "
+    				+" adminInfo TEXT, "
+    				+" advertising BOOLEAN, "
+    				+" algorithm VARCHAR(8), "
+    				+" alias TEXT, "
+    				+" allowHighResdownload BOOLEAN, "
+    				+" allowOnsiteAccess BOOLEAN, "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" altform TEXT, "
+    				+" arrangement TEXT, "
+    				+" australianContent BOOLEAN, "
+    				+" bestCopy VARCHAR(1), "
+    				+" bibId VARCHAR(16), "
+    				+" bibLevel VARCHAR(9), "
+    				+" bibliography TEXT, "
+    				+" captions VARCHAR(255), "
+    				+" carrier VARCHAR(24), "
+    				+" category TEXT, "
+    				+" childRange TEXT, "
+    				+" classification TEXT, "
+    				+" collection VARCHAR(7), "
+    				+" collectionNumber VARCHAR(49), "
+    				+" commentsExternal TEXT, "
+    				+" commentsInternal TEXT, "
+    				+" commercialStatus VARCHAR(10), "
+    				+" copyCondition TEXT, "
+    				+" availabilityConstraint TEXT, "
+    				+" contributor TEXT, "
+    				+" coordinates TEXT, "
+    				+" copyingPublishing TEXT, "
+    				+" copyrightPolicy VARCHAR(31), "
+    				+" copyRole VARCHAR(3), "
+    				+" copyStatus VARCHAR(8), "
+    				+" copyType VARCHAR(9), "
+    				+" correspondenceHeader TEXT, "
+    				+" correspondenceId TEXT, "
+    				+" correspondenceIndex TEXT, "
+    				+" coverage TEXT, "
+    				+" creator TEXT, "
+    				+" creatorStatement TEXT, "
+    				+" currentVersion VARCHAR(3), "
+    				+" dateCreated DATETIME, "
+    				+" dateRangeInAS VARCHAR(9), "
+    				+" dcmAltPi VARCHAR(52), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" dcmDateTimeCreated DATETIME, "
+    				+" dcmDateTimeUpdated DATETIME, "
+    				+" dcmRecordCreator VARCHAR(14), "
+    				+" dcmRecordUpdater VARCHAR(26), "
+    				+" dcmSourceCopy TEXT, "
+    				+" dcmWorkPid VARCHAR(31), "
+    				+" depositType VARCHAR(16), "
+    				+" digitalStatus VARCHAR(18), "
+    				+" digitalStatusDate DATETIME, "
+    				+" displayTitlePage BOOLEAN, "
+    				+" eadUpdateReviewRequired VARCHAR(1), "
+    				+" edition TEXT, "
+    				+" encodingLevel VARCHAR(47), "
+    				+" endChild TEXT, "
+    				+" endDate DATETIME, "
+    				+" eventNote TEXT, "
+    				+" exhibition TEXT, "
+    				+" expiryDate DATETIME, "
+    				+" extent TEXT, "
+    				+" findingAidNote TEXT, "
+    				+" firstPart VARCHAR(27), "
+    				+" folder TEXT, "
+    				+" folderNumber TEXT, "
+    				+" folderType VARCHAR(31), "
+    				+" form VARCHAR(19), "
+    				+" genre VARCHAR(11), "
+    				+" heading TEXT, "
+    				+" holdingId VARCHAR(7), "
+    				+" holdingNumber TEXT, "
+    				+" html TEXT, "
+    				+" illustrated BOOLEAN, "
+    				+" ilmsSentDateTime DATETIME, "
+    				+" immutable VARCHAR(12), "
+    				+" ingestJobId BIGINT, "
+    				+" interactiveIndexAvailable BOOLEAN, "
+    				+" internalAccessConditions TEXT, "
+    				+" isMissingPage BOOLEAN, "
+    				+" issn TEXT, "
+    				+" issueDate DATETIME, "
+    				+" language VARCHAR(35), "
+    				+" localSystemNumber VARCHAR(39), "
+    				+" manipulation VARCHAR(46), "
+    				+" materialFromMultipleSources BOOLEAN, "
+    				+" materialType VARCHAR(12), "
+    				+" metsId VARCHAR(8), "
+    				+" moreIlmsDetailsRequired BOOLEAN, "
+    				+" notes VARCHAR(30), "
+    				+" occupation TEXT, "
+    				+" otherNumbers VARCHAR(7), "
+    				+" otherTitle TEXT, "
+    				+" preferredCitation TEXT, "
+    				+" preservicaId VARCHAR(36), "
+    				+" preservicaType VARCHAR(15), "
+    				+" printedPageNumber VARCHAR(14), "
+    				+" provenance TEXT, "
+    				+" publicationCategory VARCHAR(11), "
+    				+" publicationLevel TEXT, "
+    				+" publicNotes TEXT, "
+    				+" publisher TEXT, "
+    				+" rdsAcknowledgementReceiver TEXT, "
+    				+" rdsAcknowledgementType VARCHAR(7), "
+    				+" recordSource VARCHAR(8), "
+    				+" relatedMaterial TEXT, "
+    				+" repository VARCHAR(30), "
+    				+" restrictionsOnAccess TEXT, "
+    				+" restrictionType TEXT, "
+    				+" rights TEXT, "
+    				+" scaleEtc TEXT, "
+    				+" scopeContent TEXT, "
+    				+" segmentIndicator TEXT, "
+    				+" sendToIlms BOOLEAN, "
+    				+" sensitiveMaterial VARCHAR(3), "
+    				+" sensitiveReason TEXT, "
+    				+" series TEXT, "
+    				+" sheetCreationDate TEXT, "
+    				+" sheetName VARCHAR(49), "
+    				+" standardId TEXT, "
+    				+" startChild VARCHAR(17), "
+    				+" startDate DATETIME, "
+    				+" subHeadings TEXT, "
+    				+" subject TEXT, "
+    				+" subType VARCHAR(7), "
+    				+" subUnitNo TEXT, "
+    				+" subUnitType VARCHAR(23), "
+    				+" summary TEXT, "
+    				+" tempHolding VARCHAR(2), "
+    				+" tilePosition TEXT, "
+    				+" timedStatus VARCHAR(9), "
+    				+" title TEXT, "
+    				+" totalDuration VARCHAR(10), "
+    				+" uniformTitle TEXT, "
+    				+" vendorId VARCHAR(7), "
+    				+" versionNumber VARCHAR(1), "
+    				+" workCreatedDuringMigration BOOLEAN, "
+    				+" workPid TEXT)  ; "
+    				+"CREATE INDEX work_id ON work (id); "
+    				+"CREATE INDEX work_txn_id ON work (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS work_history; "
+    				+"CREATE TABLE IF NOT EXISTS work_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" abstract TEXT, "
+    				+" access TEXT, "
+    				+" accessConditions VARCHAR(13), "
+    				+" acquisitionCategory VARCHAR(19), "
+    				+" acquisitionStatus VARCHAR(7), "
+    				+" additionalContributor TEXT, "
+    				+" additionalCreator TEXT, "
+    				+" additionalSeries TEXT, "
+    				+" additionalSeriesStatement VARCHAR(42), "
+    				+" additionalTitle TEXT, "
+    				+" addressee TEXT, "
+    				+" adminInfo TEXT, "
+    				+" advertising BOOLEAN, "
+    				+" algorithm VARCHAR(8), "
+    				+" alias TEXT, "
+    				+" allowHighResdownload BOOLEAN, "
+    				+" allowOnsiteAccess BOOLEAN, "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" altform TEXT, "
+    				+" arrangement TEXT, "
+    				+" australianContent BOOLEAN, "
+    				+" bestCopy VARCHAR(1), "
+    				+" bibId VARCHAR(16), "
+    				+" bibLevel VARCHAR(9), "
+    				+" bibliography TEXT, "
+    				+" captions VARCHAR(255), "
+    				+" carrier VARCHAR(24), "
+    				+" category TEXT, "
+    				+" childRange TEXT, "
+    				+" classification TEXT, "
+    				+" collection VARCHAR(7), "
+    				+" collectionNumber VARCHAR(49), "
+    				+" commentsExternal TEXT, "
+    				+" commentsInternal TEXT, "
+    				+" commercialStatus VARCHAR(10), "
+    				+" copyCondition TEXT, "
+    				+" availabilityConstraint TEXT, "
+    				+" contributor TEXT, "
+    				+" coordinates TEXT, "
+    				+" copyingPublishing TEXT, "
+    				+" copyrightPolicy VARCHAR(31), "
+    				+" copyRole VARCHAR(3), "
+    				+" copyStatus VARCHAR(8), "
+    				+" copyType VARCHAR(9), "
+    				+" correspondenceHeader TEXT, "
+    				+" correspondenceId TEXT, "
+    				+" correspondenceIndex TEXT, "
+    				+" coverage TEXT, "
+    				+" creator TEXT, "
+    				+" creatorStatement TEXT, "
+    				+" currentVersion VARCHAR(3), "
+    				+" dateCreated DATETIME, "
+    				+" dateRangeInAS VARCHAR(9), "
+    				+" dcmAltPi VARCHAR(52), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" dcmDateTimeCreated DATETIME, "
+    				+" dcmDateTimeUpdated DATETIME, "
+    				+" dcmRecordCreator VARCHAR(14), "
+    				+" dcmRecordUpdater VARCHAR(26), "
+    				+" dcmSourceCopy TEXT, "
+    				+" dcmWorkPid VARCHAR(31), "
+    				+" depositType VARCHAR(16), "
+    				+" digitalStatus VARCHAR(18), "
+    				+" digitalStatusDate DATETIME, "
+    				+" displayTitlePage BOOLEAN, "
+    				+" eadUpdateReviewRequired VARCHAR(1), "
+    				+" edition TEXT, "
+    				+" encodingLevel VARCHAR(47), "
+    				+" endChild TEXT, "
+    				+" endDate DATETIME, "
+    				+" eventNote TEXT, "
+    				+" exhibition TEXT, "
+    				+" expiryDate DATETIME, "
+    				+" extent TEXT, "
+    				+" findingAidNote TEXT, "
+    				+" firstPart VARCHAR(27), "
+    				+" folder TEXT, "
+    				+" folderNumber TEXT, "
+    				+" folderType VARCHAR(31), "
+    				+" form VARCHAR(19), "
+    				+" genre VARCHAR(11), "
+    				+" heading TEXT, "
+    				+" holdingId VARCHAR(7), "
+    				+" holdingNumber TEXT, "
+    				+" html TEXT, "
+    				+" illustrated BOOLEAN, "
+    				+" ilmsSentDateTime DATETIME, "
+    				+" immutable VARCHAR(12), "
+    				+" ingestJobId BIGINT, "
+    				+" interactiveIndexAvailable BOOLEAN, "
+    				+" internalAccessConditions TEXT, "
+    				+" isMissingPage BOOLEAN, "
+    				+" issn TEXT, "
+    				+" issueDate DATETIME, "
+    				+" language VARCHAR(35), "
+    				+" localSystemNumber VARCHAR(39), "
+    				+" manipulation VARCHAR(46), "
+    				+" materialFromMultipleSources BOOLEAN, "
+    				+" materialType VARCHAR(12), "
+    				+" metsId VARCHAR(8), "
+    				+" moreIlmsDetailsRequired BOOLEAN, "
+    				+" notes VARCHAR(30), "
+    				+" occupation TEXT, "
+    				+" otherNumbers VARCHAR(7), "
+    				+" otherTitle TEXT, "
+    				+" preferredCitation TEXT, "
+    				+" preservicaId VARCHAR(36), "
+    				+" preservicaType VARCHAR(15), "
+    				+" printedPageNumber VARCHAR(14), "
+    				+" provenance TEXT, "
+    				+" publicationCategory VARCHAR(11), "
+    				+" publicationLevel TEXT, "
+    				+" publicNotes TEXT, "
+    				+" publisher TEXT, "
+    				+" rdsAcknowledgementReceiver TEXT, "
+    				+" rdsAcknowledgementType VARCHAR(7), "
+    				+" recordSource VARCHAR(8), "
+    				+" relatedMaterial TEXT, "
+    				+" repository VARCHAR(30), "
+    				+" restrictionsOnAccess TEXT, "
+    				+" restrictionType TEXT, "
+    				+" rights TEXT, "
+    				+" scaleEtc TEXT, "
+    				+" scopeContent TEXT, "
+    				+" segmentIndicator TEXT, "
+    				+" sendToIlms BOOLEAN, "
+    				+" sensitiveMaterial VARCHAR(3), "
+    				+" sensitiveReason TEXT, "
+    				+" series TEXT, "
+    				+" sheetCreationDate TEXT, "
+    				+" sheetName VARCHAR(49), "
+    				+" standardId TEXT, "
+    				+" startChild VARCHAR(17), "
+    				+" startDate DATETIME, "
+    				+" subHeadings TEXT, "
+    				+" subject TEXT, "
+    				+" subType VARCHAR(7), "
+    				+" subUnitNo TEXT, "
+    				+" subUnitType VARCHAR(23), "
+    				+" summary TEXT, "
+    				+" tempHolding VARCHAR(2), "
+    				+" tilePosition TEXT, "
+    				+" timedStatus VARCHAR(9), "
+    				+" title TEXT, "
+    				+" totalDuration VARCHAR(10), "
+    				+" uniformTitle TEXT, "
+    				+" vendorId VARCHAR(7), "
+    				+" versionNumber VARCHAR(1), "
+    				+" workCreatedDuringMigration BOOLEAN, "
+    				+" workPid TEXT)  ; "
+    				+"CREATE INDEX work_history_id ON work_history (id); "
+    				+"CREATE INDEX work_history_txn_id ON work_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_work; "
+    				+"CREATE TABLE IF NOT EXISTS sess_work ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" abstract TEXT, "
+    				+" access TEXT, "
+    				+" accessConditions VARCHAR(13), "
+    				+" acquisitionCategory VARCHAR(19), "
+    				+" acquisitionStatus VARCHAR(7), "
+    				+" additionalContributor TEXT, "
+    				+" additionalCreator TEXT, "
+    				+" additionalSeries TEXT, "
+    				+" additionalSeriesStatement VARCHAR(42), "
+    				+" additionalTitle TEXT, "
+    				+" addressee TEXT, "
+    				+" adminInfo TEXT, "
+    				+" advertising BOOLEAN, "
+    				+" algorithm VARCHAR(8), "
+    				+" alias TEXT, "
+    				+" allowHighResdownload BOOLEAN, "
+    				+" allowOnsiteAccess BOOLEAN, "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" altform TEXT, "
+    				+" arrangement TEXT, "
+    				+" australianContent BOOLEAN, "
+    				+" bestCopy VARCHAR(1), "
+    				+" bibId VARCHAR(16), "
+    				+" bibLevel VARCHAR(9), "
+    				+" bibliography TEXT, "
+    				+" captions VARCHAR(255), "
+    				+" carrier VARCHAR(24), "
+    				+" category TEXT, "
+    				+" childRange TEXT, "
+    				+" classification TEXT, "
+    				+" collection VARCHAR(7), "
+    				+" collectionNumber VARCHAR(49), "
+    				+" commentsExternal TEXT, "
+    				+" commentsInternal TEXT, "
+    				+" commercialStatus VARCHAR(10), "
+    				+" copyCondition TEXT, "
+    				+" availabilityConstraint TEXT, "
+    				+" contributor TEXT, "
+    				+" coordinates TEXT, "
+    				+" copyingPublishing TEXT, "
+    				+" copyrightPolicy VARCHAR(31), "
+    				+" copyRole VARCHAR(3), "
+    				+" copyStatus VARCHAR(8), "
+    				+" copyType VARCHAR(9), "
+    				+" correspondenceHeader TEXT, "
+    				+" correspondenceId TEXT, "
+    				+" correspondenceIndex TEXT, "
+    				+" coverage TEXT, "
+    				+" creator TEXT, "
+    				+" creatorStatement TEXT, "
+    				+" currentVersion VARCHAR(3), "
+    				+" dateCreated DATETIME, "
+    				+" dateRangeInAS VARCHAR(9), "
+    				+" dcmAltPi VARCHAR(52), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" dcmDateTimeCreated DATETIME, "
+    				+" dcmDateTimeUpdated DATETIME, "
+    				+" dcmRecordCreator VARCHAR(14), "
+    				+" dcmRecordUpdater VARCHAR(26), "
+    				+" dcmSourceCopy TEXT, "
+    				+" dcmWorkPid VARCHAR(31), "
+    				+" depositType VARCHAR(16), "
+    				+" digitalStatus VARCHAR(18), "
+    				+" digitalStatusDate DATETIME, "
+    				+" displayTitlePage BOOLEAN, "
+    				+" eadUpdateReviewRequired VARCHAR(1), "
+    				+" edition TEXT, "
+    				+" encodingLevel VARCHAR(47), "
+    				+" endChild TEXT, "
+    				+" endDate DATETIME, "
+    				+" eventNote TEXT, "
+    				+" exhibition TEXT, "
+    				+" expiryDate DATETIME, "
+    				+" extent TEXT, "
+    				+" findingAidNote TEXT, "
+    				+" firstPart VARCHAR(27), "
+    				+" folder TEXT, "
+    				+" folderNumber TEXT, "
+    				+" folderType VARCHAR(31), "
+    				+" form VARCHAR(19), "
+    				+" genre VARCHAR(11), "
+    				+" heading TEXT, "
+    				+" holdingId VARCHAR(7), "
+    				+" holdingNumber TEXT, "
+    				+" html TEXT, "
+    				+" illustrated BOOLEAN, "
+    				+" ilmsSentDateTime DATETIME, "
+    				+" immutable VARCHAR(12), "
+    				+" ingestJobId BIGINT, "
+    				+" interactiveIndexAvailable BOOLEAN, "
+    				+" internalAccessConditions TEXT, "
+    				+" isMissingPage BOOLEAN, "
+    				+" issn TEXT, "
+    				+" issueDate DATETIME, "
+    				+" language VARCHAR(35), "
+    				+" localSystemNumber VARCHAR(39), "
+    				+" manipulation VARCHAR(46), "
+    				+" materialFromMultipleSources BOOLEAN, "
+    				+" materialType VARCHAR(12), "
+    				+" metsId VARCHAR(8), "
+    				+" moreIlmsDetailsRequired BOOLEAN, "
+    				+" notes VARCHAR(30), "
+    				+" occupation TEXT, "
+    				+" otherNumbers VARCHAR(7), "
+    				+" otherTitle TEXT, "
+    				+" preferredCitation TEXT, "
+    				+" preservicaId VARCHAR(36), "
+    				+" preservicaType VARCHAR(15), "
+    				+" printedPageNumber VARCHAR(14), "
+    				+" provenance TEXT, "
+    				+" publicationCategory VARCHAR(11), "
+    				+" publicationLevel TEXT, "
+    				+" publicNotes TEXT, "
+    				+" publisher TEXT, "
+    				+" rdsAcknowledgementReceiver TEXT, "
+    				+" rdsAcknowledgementType VARCHAR(7), "
+    				+" recordSource VARCHAR(8), "
+    				+" relatedMaterial TEXT, "
+    				+" repository VARCHAR(30), "
+    				+" restrictionsOnAccess TEXT, "
+    				+" restrictionType TEXT, "
+    				+" rights TEXT, "
+    				+" scaleEtc TEXT, "
+    				+" scopeContent TEXT, "
+    				+" segmentIndicator TEXT, "
+    				+" sendToIlms BOOLEAN, "
+    				+" sensitiveMaterial VARCHAR(3), "
+    				+" sensitiveReason TEXT, "
+    				+" series TEXT, "
+    				+" sheetCreationDate TEXT, "
+    				+" sheetName VARCHAR(49), "
+    				+" standardId TEXT, "
+    				+" startChild VARCHAR(17), "
+    				+" startDate DATETIME, "
+    				+" subHeadings TEXT, "
+    				+" subject TEXT, "
+    				+" subType VARCHAR(7), "
+    				+" subUnitNo TEXT, "
+    				+" subUnitType VARCHAR(23), "
+    				+" summary TEXT, "
+    				+" tempHolding VARCHAR(2), "
+    				+" tilePosition TEXT, "
+    				+" timedStatus VARCHAR(9), "
+    				+" title TEXT, "
+    				+" totalDuration VARCHAR(10), "
+    				+" uniformTitle TEXT, "
+    				+" vendorId VARCHAR(7), "
+    				+" versionNumber VARCHAR(1), "
+    				+" workCreatedDuringMigration BOOLEAN, "
+    				+" workPid TEXT)  ; "
+    				+"CREATE INDEX sess_work_id ON sess_work (id); "
+    				+"CREATE INDEX sess_work_txn_id ON sess_work (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS file; "
+    				+"CREATE TABLE IF NOT EXISTS file ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" application TEXT, "
+    				+" applicationDateCreated VARCHAR(19), "
+    				+" bitDepth VARCHAR(8), "
+    				+" bitrate VARCHAR(3), "
+    				+" blobId BIGINT, "
+    				+" blockAlign INTEGER, "
+    				+" brand VARCHAR(27), "
+    				+" carrierCapacity VARCHAR(7), "
+    				+" channel VARCHAR(3), "
+    				+" checksum VARCHAR(40), "
+    				+" checksumGenerationDate DATETIME, "
+    				+" checksumType VARCHAR(4), "
+    				+" codec VARCHAR(4), "
+    				+" colourProfile VARCHAR(9), "
+    				+" colourSpace VARCHAR(15), "
+    				+" compression VARCHAR(9), "
+    				+" cpLocation TEXT, "
+    				+" dateDigitised VARCHAR(19), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" device VARCHAR(44), "
+    				+" deviceSerialNumber VARCHAR(20), "
+    				+" duration VARCHAR(12), "
+    				+" durationType VARCHAR(7), "
+    				+" encoding VARCHAR(10), "
+    				+" equalisation VARCHAR(4), "
+    				+" fileContainer VARCHAR(3), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileFormatVersion VARCHAR(3), "
+    				+" fileName TEXT, "
+    				+" fileSize BIGINT, "
+    				+" framerate INTEGER, "
+    				+" imageLength INTEGER, "
+    				+" imageWidth INTEGER, "
+    				+" location TEXT, "
+    				+" manufacturerMake VARCHAR(27), "
+    				+" manufacturerModelName VARCHAR(41), "
+    				+" manufacturerSerialNumber VARCHAR(12), "
+    				+" mimeType TEXT, "
+    				+" orientation VARCHAR(36), "
+    				+" photometric TEXT, "
+    				+" reelSize VARCHAR(12), "
+    				+" resolution VARCHAR(37), "
+    				+" resolutionUnit VARCHAR(4), "
+    				+" samplesPerPixel TEXT, "
+    				+" samplingRate VARCHAR(5), "
+    				+" software VARCHAR(33), "
+    				+" softwareSerialNumber VARCHAR(10), "
+    				+" soundField VARCHAR(9), "
+    				+" speed VARCHAR(10), "
+    				+" surface VARCHAR(20), "
+    				+" thickness VARCHAR(11), "
+    				+" toolId VARCHAR(13), "
+    				+" zoomLevel TEXT)  ; "
+    				+"CREATE INDEX file_id ON file (id); "
+    				+"CREATE INDEX file_txn_id ON file (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS file_history; "
+    				+"CREATE TABLE IF NOT EXISTS file_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" application TEXT, "
+    				+" applicationDateCreated VARCHAR(19), "
+    				+" bitDepth VARCHAR(8), "
+    				+" bitrate VARCHAR(3), "
+    				+" blobId BIGINT, "
+    				+" blockAlign INTEGER, "
+    				+" brand VARCHAR(27), "
+    				+" carrierCapacity VARCHAR(7), "
+    				+" channel VARCHAR(3), "
+    				+" checksum VARCHAR(40), "
+    				+" checksumGenerationDate DATETIME, "
+    				+" checksumType VARCHAR(4), "
+    				+" codec VARCHAR(4), "
+    				+" colourProfile VARCHAR(9), "
+    				+" colourSpace VARCHAR(15), "
+    				+" compression VARCHAR(9), "
+    				+" cpLocation TEXT, "
+    				+" dateDigitised VARCHAR(19), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" device VARCHAR(44), "
+    				+" deviceSerialNumber VARCHAR(20), "
+    				+" duration VARCHAR(12), "
+    				+" durationType VARCHAR(7), "
+    				+" encoding VARCHAR(10), "
+    				+" equalisation VARCHAR(4), "
+    				+" fileContainer VARCHAR(3), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileFormatVersion VARCHAR(3), "
+    				+" fileName TEXT, "
+    				+" fileSize BIGINT, "
+    				+" framerate INTEGER, "
+    				+" imageLength INTEGER, "
+    				+" imageWidth INTEGER, "
+    				+" location TEXT, "
+    				+" manufacturerMake VARCHAR(27), "
+    				+" manufacturerModelName VARCHAR(41), "
+    				+" manufacturerSerialNumber VARCHAR(12), "
+    				+" mimeType TEXT, "
+    				+" orientation VARCHAR(36), "
+    				+" photometric TEXT, "
+    				+" reelSize VARCHAR(12), "
+    				+" resolution VARCHAR(37), "
+    				+" resolutionUnit VARCHAR(4), "
+    				+" samplesPerPixel TEXT, "
+    				+" samplingRate VARCHAR(5), "
+    				+" software VARCHAR(33), "
+    				+" softwareSerialNumber VARCHAR(10), "
+    				+" soundField VARCHAR(9), "
+    				+" speed VARCHAR(10), "
+    				+" surface VARCHAR(20), "
+    				+" thickness VARCHAR(11), "
+    				+" toolId VARCHAR(13), "
+    				+" zoomLevel TEXT)  ; "
+    				+"CREATE INDEX file_history_id ON file_history (id); "
+    				+"CREATE INDEX file_history_txn_id ON file_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_file; "
+    				+"CREATE TABLE IF NOT EXISTS sess_file ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" application TEXT, "
+    				+" applicationDateCreated VARCHAR(19), "
+    				+" bitDepth VARCHAR(8), "
+    				+" bitrate VARCHAR(3), "
+    				+" blobId BIGINT, "
+    				+" blockAlign INTEGER, "
+    				+" brand VARCHAR(27), "
+    				+" carrierCapacity VARCHAR(7), "
+    				+" channel VARCHAR(3), "
+    				+" checksum VARCHAR(40), "
+    				+" checksumGenerationDate DATETIME, "
+    				+" checksumType VARCHAR(4), "
+    				+" codec VARCHAR(4), "
+    				+" colourProfile VARCHAR(9), "
+    				+" colourSpace VARCHAR(15), "
+    				+" compression VARCHAR(9), "
+    				+" cpLocation TEXT, "
+    				+" dateDigitised VARCHAR(19), "
+    				+" dcmCopyPid VARCHAR(37), "
+    				+" device VARCHAR(44), "
+    				+" deviceSerialNumber VARCHAR(20), "
+    				+" duration VARCHAR(12), "
+    				+" durationType VARCHAR(7), "
+    				+" encoding VARCHAR(10), "
+    				+" equalisation VARCHAR(4), "
+    				+" fileContainer VARCHAR(3), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileFormatVersion VARCHAR(3), "
+    				+" fileName TEXT, "
+    				+" fileSize BIGINT, "
+    				+" framerate INTEGER, "
+    				+" imageLength INTEGER, "
+    				+" imageWidth INTEGER, "
+    				+" location TEXT, "
+    				+" manufacturerMake VARCHAR(27), "
+    				+" manufacturerModelName VARCHAR(41), "
+    				+" manufacturerSerialNumber VARCHAR(12), "
+    				+" mimeType TEXT, "
+    				+" orientation VARCHAR(36), "
+    				+" photometric TEXT, "
+    				+" reelSize VARCHAR(12), "
+    				+" resolution VARCHAR(37), "
+    				+" resolutionUnit VARCHAR(4), "
+    				+" samplesPerPixel TEXT, "
+    				+" samplingRate VARCHAR(5), "
+    				+" software VARCHAR(33), "
+    				+" softwareSerialNumber VARCHAR(10), "
+    				+" soundField VARCHAR(9), "
+    				+" speed VARCHAR(10), "
+    				+" surface VARCHAR(20), "
+    				+" thickness VARCHAR(11), "
+    				+" toolId VARCHAR(13), "
+    				+" zoomLevel TEXT)  ; "
+    				+"CREATE INDEX sess_file_id ON sess_file (id); "
+    				+"CREATE INDEX sess_file_txn_id ON sess_file (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS description; "
+    				+"CREATE TABLE IF NOT EXISTS description ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" city VARCHAR(25), "
+    				+" country TEXT, "
+    				+" digitalSourceType TEXT, "
+    				+" event TEXT, "
+    				+" exposureFNumber VARCHAR(5), "
+    				+" exposureMode VARCHAR(15), "
+    				+" exposureProgram VARCHAR(19), "
+    				+" exposureTime VARCHAR(17), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileSource VARCHAR(26), "
+    				+" focalLength VARCHAR(8), "
+    				+" gpsVersion TEXT, "
+    				+" isoCountryCode TEXT, "
+    				+" isoSpeedRating VARCHAR(5), "
+    				+" latitude VARCHAR(33), "
+    				+" latitudeRef TEXT, "
+    				+" lens VARCHAR(27), "
+    				+" longitude VARCHAR(31), "
+    				+" longitudeRef TEXT, "
+    				+" mapDatum VARCHAR(6), "
+    				+" meteringMode VARCHAR(23), "
+    				+" province VARCHAR(13), "
+    				+" subLocation TEXT, "
+    				+" timestamp DATETIME, "
+    				+" whiteBalance VARCHAR(18), "
+    				+" worldRegion TEXT)  ; "
+    				+"CREATE INDEX description_id ON description (id); "
+    				+"CREATE INDEX description_txn_id ON description (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS description_history; "
+    				+"CREATE TABLE IF NOT EXISTS description_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" city VARCHAR(25), "
+    				+" country TEXT, "
+    				+" digitalSourceType TEXT, "
+    				+" event TEXT, "
+    				+" exposureFNumber VARCHAR(5), "
+    				+" exposureMode VARCHAR(15), "
+    				+" exposureProgram VARCHAR(19), "
+    				+" exposureTime VARCHAR(17), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileSource VARCHAR(26), "
+    				+" focalLength VARCHAR(8), "
+    				+" gpsVersion TEXT, "
+    				+" isoCountryCode TEXT, "
+    				+" isoSpeedRating VARCHAR(5), "
+    				+" latitude VARCHAR(33), "
+    				+" latitudeRef TEXT, "
+    				+" lens VARCHAR(27), "
+    				+" longitude VARCHAR(31), "
+    				+" longitudeRef TEXT, "
+    				+" mapDatum VARCHAR(6), "
+    				+" meteringMode VARCHAR(23), "
+    				+" province VARCHAR(13), "
+    				+" subLocation TEXT, "
+    				+" timestamp DATETIME, "
+    				+" whiteBalance VARCHAR(18), "
+    				+" worldRegion TEXT)  ; "
+    				+"CREATE INDEX description_history_id ON description_history (id); "
+    				+"CREATE INDEX description_history_txn_id ON description_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_description; "
+    				+"CREATE TABLE IF NOT EXISTS sess_description ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" alternativeTitle VARCHAR(20), "
+    				+" city VARCHAR(25), "
+    				+" country TEXT, "
+    				+" digitalSourceType TEXT, "
+    				+" event TEXT, "
+    				+" exposureFNumber VARCHAR(5), "
+    				+" exposureMode VARCHAR(15), "
+    				+" exposureProgram VARCHAR(19), "
+    				+" exposureTime VARCHAR(17), "
+    				+" fileFormat VARCHAR(20), "
+    				+" fileSource VARCHAR(26), "
+    				+" focalLength VARCHAR(8), "
+    				+" gpsVersion TEXT, "
+    				+" isoCountryCode TEXT, "
+    				+" isoSpeedRating VARCHAR(5), "
+    				+" latitude VARCHAR(33), "
+    				+" latitudeRef TEXT, "
+    				+" lens VARCHAR(27), "
+    				+" longitude VARCHAR(31), "
+    				+" longitudeRef TEXT, "
+    				+" mapDatum VARCHAR(6), "
+    				+" meteringMode VARCHAR(23), "
+    				+" province VARCHAR(13), "
+    				+" subLocation TEXT, "
+    				+" timestamp DATETIME, "
+    				+" whiteBalance VARCHAR(18), "
+    				+" worldRegion TEXT)  ; "
+    				+"CREATE INDEX sess_description_id ON sess_description (id); "
+    				+"CREATE INDEX sess_description_txn_id ON sess_description (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS party; "
+    				+"CREATE TABLE IF NOT EXISTS party ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" orgUrl TEXT, "
+    				+" suppressed BOOLEAN, "
+    				+" logoUrl VARCHAR(17))  ; "
+    				+"CREATE INDEX party_id ON party (id); "
+    				+"CREATE INDEX party_txn_id ON party (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS party_history; "
+    				+"CREATE TABLE IF NOT EXISTS party_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" orgUrl TEXT, "
+    				+" suppressed BOOLEAN, "
+    				+" logoUrl VARCHAR(17))  ; "
+    				+"CREATE INDEX party_history_id ON party_history (id); "
+    				+"CREATE INDEX party_history_txn_id ON party_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_party; "
+    				+"CREATE TABLE IF NOT EXISTS sess_party ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" orgUrl TEXT, "
+    				+" suppressed BOOLEAN, "
+    				+" logoUrl VARCHAR(17))  ; "
+    				+"CREATE INDEX sess_party_id ON sess_party (id); "
+    				+"CREATE INDEX sess_party_txn_id ON sess_party (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS tag; "
+    				+"CREATE TABLE IF NOT EXISTS tag ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" description TEXT)  ; "
+    				+"CREATE INDEX tag_id ON tag (id); "
+    				+"CREATE INDEX tag_txn_id ON tag (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS tag_history; "
+    				+"CREATE TABLE IF NOT EXISTS tag_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" description TEXT)  ; "
+    				+"CREATE INDEX tag_history_id ON tag_history (id); "
+    				+"CREATE INDEX tag_history_txn_id ON tag_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_tag; "
+    				+"CREATE TABLE IF NOT EXISTS sess_tag ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" name TEXT, "
+    				+" description TEXT)  ; "
+    				+"CREATE INDEX sess_tag_id ON sess_tag (id); "
+    				+"CREATE INDEX sess_tag_txn_id ON sess_tag (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS flatedge; "
+    				+"CREATE TABLE IF NOT EXISTS flatedge ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" v_out BIGINT, "
+    				+" v_in BIGINT, "
+    				+" edge_order BIGINT)  ; "
+    				+"CREATE INDEX flatedge_id ON flatedge (id); "
+    				+"CREATE INDEX flatedge_txn_id ON flatedge (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS flatedge_history; "
+    				+"CREATE TABLE IF NOT EXISTS flatedge_history ( "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" v_out BIGINT, "
+    				+" v_in BIGINT, "
+    				+" edge_order BIGINT)  ; "
+    				+"CREATE INDEX flatedge_history_id ON flatedge_history (id); "
+    				+"CREATE INDEX flatedge_history_txn_id ON flatedge_history (id, txn_start, txn_end); "
+    				+"DROP TABLE IF EXISTS sess_flatedge; "
+    				+"CREATE TABLE IF NOT EXISTS sess_flatedge ( "
+    				+" s_id BIGINT, "
+    				+" state CHAR(3), "
+    				+" id BIGINT, "
+    				+" txn_start BIGINT DEFAULT 0 NOT NULL, "
+    				+" txn_end BIGINT DEFAULT 0 NOT NULL, "
+    				+" type VARCHAR(15), "
+    				+" "
+    				+" v_out BIGINT, "
+    				+" v_in BIGINT, "
+    				+" edge_order BIGINT)  ; "
+    				+"CREATE INDEX sess_flatedge_id ON sess_flatedge (id); "
+    				+"CREATE INDEX sess_flatedge_txn_id ON sess_flatedge (id, txn_start, txn_end); ")
     public abstract void createV2Tables();
 
     @SqlQuery(
@@ -2565,7 +1552,7 @@ public abstract class AmberDao implements Transactional<AmberDao>, GetHandle {
 
 	// The following query intentionally left blank. It's implemented in the db specific AmberDao sub classes (h2 or MySql)
 	@SqlUpdate("")
-	public abstract void endPartys(
+	public abstract void endParties(
 	@Bind("txnId") Long txnId);
 
 	@SqlUpdate("SET @txn = :txnId;"
@@ -2592,7 +1579,7 @@ public abstract class AmberDao implements Transactional<AmberDao>, GetHandle {
 	 + "WHERE c.id = s.id "
 	 + "AND s_id = @txn "
 	 + "AND state = 'MOD';")
-	public abstract void startPartys(
+	public abstract void startParties(
 	@Bind("txnId") Long txnId);
 
 	// The following query intentionally left blank. It's implemented in the db specific AmberDao sub classes (h2 or MySql)

--- a/src/amberdb/graph/dao/AmberDaoH2.java
+++ b/src/amberdb/graph/dao/AmberDaoH2.java
@@ -71,24 +71,77 @@ public abstract class AmberDaoH2 extends AmberDao {
     public abstract void endElements(
             @Bind("txnId") Long txnId);
     
-    @SqlUpdate("SET @txn = :txnId;\n"
-            + "UPDATE work_history w "
-            + "SET txn_end = @txn "
-            + "WHERE w.txn_end = 0 "
-            + "AND w.id IN ("
-            + "  SELECT id "
-            + "  FROM sess_work "
-            + "  WHERE s_id = @txn "
-            + "  AND state <> 'AMB');\n"
-            
-    		+ "DELETE FROM work w "
-            + "WHERE w.txn_end = 0 "
-            + "AND w.id IN ("
-            + "  SELECT id "
-            + "  FROM sess_work "
-            + "  WHERE s_id = @txn "
-            + "  AND state = 'DEL');\n")
-    public abstract void endWorks(
-            @Bind("txnId") Long txnId);
+    
+    @SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE work_history h "
+    		 + "SET txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id IN (SELECT id FROM sess_work WHERE s_id = @txn AND STATE <> 'AMB');"
+    		 + " "
+    		 + "DELETE FROM work c "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id IN (SELECT id FROM sess_work WHERE s_id = @txn AND STATE = 'DEL');")
+    		public abstract void endWorks(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE file_history h "
+    		 + "SET txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id IN (SELECT id FROM sess_file WHERE s_id = @txn AND STATE <> 'AMB');"
+    		 + " "
+    		 + "DELETE FROM file c "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id IN (SELECT id FROM sess_file WHERE s_id = @txn AND STATE = 'DEL');")
+    		public abstract void endFiles(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE description_history h "
+    		 + "SET txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id IN (SELECT id FROM sess_description WHERE s_id = @txn AND STATE <> 'AMB');"
+    		 + " "
+    		 + "DELETE FROM description c "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id IN (SELECT id FROM sess_description WHERE s_id = @txn AND STATE = 'DEL');")
+    		public abstract void endDescriptions(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE party_history h "
+    		 + "SET txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id IN (SELECT id FROM sess_party WHERE s_id = @txn AND STATE <> 'AMB');"
+    		 + " "
+    		 + "DELETE FROM party c "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id IN (SELECT id FROM sess_party WHERE s_id = @txn AND STATE = 'DEL');")
+    		public abstract void endPartys(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE tag_history h "
+    		 + "SET txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id IN (SELECT id FROM sess_tag WHERE s_id = @txn AND STATE <> 'AMB');"
+    		 + " "
+    		 + "DELETE FROM tag c "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id IN (SELECT id FROM sess_tag WHERE s_id = @txn AND STATE = 'DEL');")
+    		public abstract void endTags(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    				 + "UPDATE flatedge_history h "
+    				 + "SET txn_end = @txn "
+    				 + "WHERE h.txn_end = 0 "
+    				 + "AND h.id IN (SELECT id FROM sess_flatedge WHERE s_id = @txn AND STATE <> 'AMB');"
+    				 + " "
+    				 + "DELETE FROM flatedge c "
+    				 + "WHERE c.txn_end = 0 "
+    				 + "AND c.id IN (SELECT id FROM sess_flatedge WHERE s_id = @txn AND STATE = 'DEL');")
+    				public abstract void endFlatedges(
+    				@Bind("txnId") Long txnId);   
 }
 

--- a/src/amberdb/graph/dao/AmberDaoH2.java
+++ b/src/amberdb/graph/dao/AmberDaoH2.java
@@ -117,7 +117,7 @@ public abstract class AmberDaoH2 extends AmberDao {
     		 + "DELETE FROM party c "
     		 + "WHERE c.txn_end = 0 "
     		 + "AND c.id IN (SELECT id FROM sess_party WHERE s_id = @txn AND STATE = 'DEL');")
-    		public abstract void endPartys(
+    		public abstract void endParties(
     		@Bind("txnId") Long txnId);
 
     		@SqlUpdate("SET @txn = :txnId;"

--- a/src/amberdb/graph/dao/AmberDaoMySql.java
+++ b/src/amberdb/graph/dao/AmberDaoMySql.java
@@ -125,7 +125,7 @@ public abstract class AmberDaoMySql extends AmberDao {
     		 + "AND c.id = s.id "
     		 + "AND s.s_id = @txn "
     		 + "AND s.state = 'DEL';")
-    		public abstract void endPartys(
+    		public abstract void endParties(
     		@Bind("txnId") Long txnId);
 
     		@SqlUpdate("SET @txn = :txnId;"

--- a/src/amberdb/graph/dao/AmberDaoMySql.java
+++ b/src/amberdb/graph/dao/AmberDaoMySql.java
@@ -59,21 +59,108 @@ public abstract class AmberDaoMySql extends AmberDao {
     public abstract void endElements(
           @Bind("txnId") Long txnId);
     
-    @SqlUpdate("SET @txn = :txnId;\n"
-            + "UPDATE work_history w, sess_vertex s "
-            + "SET w.txn_end = @txn "
-            + "WHERE w.txn_end = 0 "
-            + "AND w.id = s.id "
-            + "AND s.s_id = @txn "
-            + "AND s.state <> 'AMB';\n"
-            
-			+ "DELETE w "
-			+ "FROM work w, sess_vertex s "
-			+ "WHERE w.txn_end = 0 "
-			+ "AND w.id = s.id "
-			+ "AND s.s_id = @txn "
-			+ "AND s.state = 'DEL';\n")
-    public abstract void endWorks(
-          @Bind("txnId") Long txnId);
+    
+    @SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE work_history h, sess_work s "
+    		 + "SET h.txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state <> 'AMB'; "
+    		 + " "
+    		 + "DELETE c "
+    		 + "FROM work c, sess_work s "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state = 'DEL';")
+    		public abstract void endWorks(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE file_history h, sess_file s "
+    		 + "SET h.txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state <> 'AMB'; "
+    		 + " "
+    		 + "DELETE c "
+    		 + "FROM file c, sess_file s "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state = 'DEL';")
+    		public abstract void endFiles(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE description_history h, sess_description s "
+    		 + "SET h.txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state <> 'AMB'; "
+    		 + " "
+    		 + "DELETE c "
+    		 + "FROM description c, sess_description s "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state = 'DEL';")
+    		public abstract void endDescriptions(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE party_history h, sess_party s "
+    		 + "SET h.txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state <> 'AMB'; "
+    		 + " "
+    		 + "DELETE c "
+    		 + "FROM party c, sess_party s "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state = 'DEL';")
+    		public abstract void endPartys(
+    		@Bind("txnId") Long txnId);
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    		 + "UPDATE tag_history h, sess_tag s "
+    		 + "SET h.txn_end = @txn "
+    		 + "WHERE h.txn_end = 0 "
+    		 + "AND h.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state <> 'AMB'; "
+    		 + " "
+    		 + "DELETE c "
+    		 + "FROM tag c, sess_tag s "
+    		 + "WHERE c.txn_end = 0 "
+    		 + "AND c.id = s.id "
+    		 + "AND s.s_id = @txn "
+    		 + "AND s.state = 'DEL';")
+    		public abstract void endTags(
+    		@Bind("txnId") Long txnId);
+    
+
+    		@SqlUpdate("SET @txn = :txnId;"
+    				 + "UPDATE flatedge_history h, sess_flatedge s "
+    				 + "SET h.txn_end = @txn "
+    				 + "WHERE h.txn_end = 0 "
+    				 + "AND h.id = s.id "
+    				 + "AND s.s_id = @txn "
+    				 + "AND s.state <> 'AMB'; "
+    				 + " "
+    				 + "DELETE c "
+    				 + "FROM flatedge c, sess_flatedge s "
+    				 + "WHERE c.txn_end = 0 "
+    				 + "AND c.id = s.id "
+    				 + "AND s.s_id = @txn "
+    				 + "AND s.state = 'DEL';")
+    				public abstract void endFlatedges(
+    				@Bind("txnId") Long txnId);
 }
 


### PR DESCRIPTION
[New pull request to merge into amberv2 not master!]

@yetti 
Hi Yetrina,

If you look at AmberGraph.vertexToTableMap and AmberGraph.edgeToTableMap you'll see that we now have a mapping between vertex types and tables and also edge types and tables, as discussed on Friday (or Thursday?).

work, eadwork, page, copy and section are all stored in the work table.
file, imagefile, movingimagefile, and soundfile are all stored in the file table.
description, cameradata, geocoding and iptc are all stored in the description table
party and tag have their own tables.

The edges are all currently stored in one table called flatedge. TODO: think of a better name.

The acknowledge edge should have its own table with appropriate fields but I haven't done that yet.

I have created all the needed tables in the amberdb2 database. Doing so has meant losing the history in the history tables. That will be my first priority next.

Actually, my first priority next will probably be to get the unit tests working again.

I have clicked around and tested a few things. I can create/modify/delete works and copies and children and it seems to work. I can see the data going in to the tables.

Talk to you tomorrow to have a sync up with what you're doing.