### PR TITLE
DDG-857: Enabled data stored in IPTC objects to be included in work reports.

### DIFF
--- a/src/amberdb/query/WorksQuery.java
+++ b/src/amberdb/query/WorksQuery.java
@@ -42,6 +42,7 @@ public class WorksQuery {
             Work work = sess.getGraph().frame(v, Work.class);
             populateFirstTransactionDetails(work, firstTransactionMap);
             populateLastTransactionDetails(work, lastTransactionMap);
+            work.getIPTC();
             works.put(Long.valueOf(work.getId()), work);
         }
         return works;


### PR DESCRIPTION
When banjo runs a report, it sets the amber session to local mode (ie: cache only mode).  This means that only work data that is cached in the session can be included in the report.  This change causes the IPTC object to be cached in the session.
@scoen @m-r-c @wibing @shuangzhou 