### PR TITLE
AmberDB changes to use v2 tables

### DIFF
--- a/src/main/java/amberdb/graph/AmberEdgeQuery.java
+++ b/src/main/java/amberdb/graph/AmberEdgeQuery.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Query;
-import org.skife.jdbi.v2.Update;
 
 import com.tinkerpop.blueprints.Edge;
 
@@ -100,9 +99,7 @@ public class AmberEdgeQuery extends AmberQueryBase {
     /* edge AND queries can't include labels currently */ 
     protected String generateAndQuery() {
         StringBuilder s = new StringBuilder();
-        s.append("select * \n" +
-        		 "from flatedge \n" +
-        		 "left join acknowledge on flatedge.id = acknowledge.id \n" +
+        s.append(EDGE_QUERY_PREFIX +
         		 "where \n");
         
         for (int i = 0; i < properties.size(); i++) {
@@ -123,12 +120,7 @@ public class AmberEdgeQuery extends AmberQueryBase {
         	if ("label".equals(columnName)) {
         		columnName = "flatedge.label";  
         	}
-            s.append(
-            		"select * \n" +
-            		"from flatedge \n" +
-            		"left join acknowledge on flatedge.id = acknowledge.id \n" +
-            		"where " + columnName + " = :value"+ i + " \n"
-                    + "UNION ALL \n");
+            s.append(EDGE_QUERY_PREFIX + "where " + columnName + " = :value"+ i + " \n UNION ALL \n");
         }
         s.setLength(s.length()-13);
         s.append(";\n");
@@ -138,10 +130,7 @@ public class AmberEdgeQuery extends AmberQueryBase {
 
     protected String generateAllQuery() {
         StringBuilder s = new StringBuilder();
-        s.append("select * \n"
-                 + "from flatedge \n"
-                 + "left join acknowledge on flatedge.id = acknowledge.id \n"
-                 + "limit " + MAX_EDGES);
+        s.append(EDGE_QUERY_PREFIX + "limit " + MAX_EDGES);
         return s.toString();
     }
 

--- a/src/main/java/amberdb/graph/AmberMultipartQuery.java
+++ b/src/main/java/amberdb/graph/AmberMultipartQuery.java
@@ -135,9 +135,8 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
         s.append(String.format(
                 "INSERT INTO v0 (step, vid, eid, label, edge_order) \n"
                 + "SELECT 0, id, 0, 'root', 0 \n"
-                + "FROM vertex \n"
-                + "WHERE id IN (%s) \n"
-                + "AND txn_end = 0; \n",
+                + "FROM node \n"
+                + "WHERE id IN (%s); \n",
                 numberListToStr(head)));
         
         s.append("INSERT INTO v1 (step, vid, eid, label, edge_order) \n"
@@ -158,9 +157,8 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
             String beginQuery = 
                     "INSERT INTO v0 (step, vid, eid, label, edge_order) \n"
                     + "SELECT " + step + ", v.id, e.id, e.label, e.edge_order  \n"
-                    + "FROM vertex v, edge e, v1 \n"
-                    + "WHERE e.txn_end = 0 \n"
-                    + "AND v.txn_end = 0 \n";
+                    + "FROM node v, flatedge e, v1 \n"
+                    + "WHERE ";
 
             String inDirection = " AND (e.v_out = v.id AND e.v_in = v1.vid) \n";
             String outDirection = " AND (e.v_in = v.id AND e.v_out = v1.vid) \n";
@@ -181,7 +179,8 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
                     + "FROM v0 \n"
                     + "WHERE v0.step = " + step + " ;\n");
         }
-        return s.toString();
+       
+        return s.toString().replaceAll("WHERE\\s*AND", "WHERE ");
         // Draw from v1 for results
     }
     

--- a/src/main/java/amberdb/graph/AmberMultipartQuery.java
+++ b/src/main/java/amberdb/graph/AmberMultipartQuery.java
@@ -213,11 +213,11 @@ public class AmberMultipartQuery extends AmberQueryBase implements AutoCloseable
     
     public List<Vertex> getResults(boolean fillEdges) {
         List<Vertex> vertices;
-        Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "v0", "vid");
+        Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h, "v0", "vid");
         vertices = getVertices(h, graph, propMaps, "v0", "vid", "edge_order");
 
         // Warning: Filled edge properties won't all be populated, only edges that were followed
-        propMaps = getElementPropertyMaps(h, "v0", "eid");
+        propMaps = getEdgePropertyMaps(h, "v0", "eid");
         if (fillEdges) {
             getFillEdges(h, graph, propMaps, "v0", "vid", "v1", "vid");
         } else {

--- a/src/main/java/amberdb/graph/AmberQuery.java
+++ b/src/main/java/amberdb/graph/AmberQuery.java
@@ -150,9 +150,8 @@ public class AmberQuery extends AmberQueryBase {
         s.append(String.format(
                 "INSERT INTO v0 (step, vid, eid, label, edge_order) \n"
                 + "SELECT 0, id, 0, 'root', 0 \n"
-                + "FROM vertex \n"
-                + "WHERE id IN (%s) \n"
-                + "AND txn_end = 0; \n",
+                + "FROM node \n"
+                + "WHERE id IN (%s); \n",
                 numberListToStr(head)));
         
         s.append("INSERT INTO v1 (step, vid, eid, label, edge_order) \n"
@@ -170,9 +169,8 @@ public class AmberQuery extends AmberQueryBase {
                 s.append(String.format(
                 "INSERT INTO v0 (step, vid, eid, label, edge_order) \n"
                 + "SELECT %1$d, v.id, e.id, e.label, e.edge_order  \n"
-                + "FROM vertex v, edge e, v1 \n"
-                + "WHERE e.txn_end = 0 \n"
-                + " AND v.txn_end = 0 \n"
+                + "FROM node v, flatedge e, v1 \n"
+                + "WHERE "
                 + labelsClause
                 + " AND (e.v_out = v.id AND e.v_in = v1.vid)\n",
                 step));
@@ -185,9 +183,8 @@ public class AmberQuery extends AmberQueryBase {
                 s.append(String.format(
                 "INSERT INTO v0 (step, vid, eid, label, edge_order) \n"
                 + "SELECT %1$d, v.id, e.id, e.label, e.edge_order  \n"
-                + "FROM vertex v, edge e, v1 \n"
-                + "WHERE e.txn_end = 0 \n"
-                + " AND v.txn_end = 0 \n"
+                + "FROM node v, flatedge e, v1 \n"
+                + "WHERE \n"
                 + labelsClause
                 + " AND (e.v_in = v.id AND e.v_out = v1.vid) \n",
                 step));
@@ -205,7 +202,7 @@ public class AmberQuery extends AmberQueryBase {
             step));
         }
 
-        return s.toString();
+        return s.toString().replaceAll("WHERE\\s*AND", "WHERE ");
         // Draw from v1 for results
     }
 

--- a/src/main/java/amberdb/graph/AmberQuery.java
+++ b/src/main/java/amberdb/graph/AmberQuery.java
@@ -263,11 +263,11 @@ public class AmberQuery extends AmberQueryBase {
             h.createStatement(generateFullSubGraphQuery()).execute();
             h.commit();
 
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "v0", "vid");
+            Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h, "v0", "vid");
             vertices = getVertices(h, graph, propMaps, "v0", "vid", "edge_order");
 
             // Warning: Filled edge properties won't all be populated 
-            propMaps = getElementPropertyMaps(h, "v0", "eid");
+            propMaps = getEdgePropertyMaps(h, "v0", "eid");
             if (fillEdges) {
                 getFillEdges(h, graph, propMaps, "v0", "vid", "v1", "vid");
             } else {

--- a/src/main/java/amberdb/graph/AmberQueryBase.java
+++ b/src/main/java/amberdb/graph/AmberQueryBase.java
@@ -22,6 +22,11 @@ public class AmberQueryBase {
                 "left join description on description.id = node.id \n" +
                 "left join party       on       party.id = node.id \n" +
                 "left join tag         on         tag.id = node.id \n";
+
+    protected static final String EDGE_QUERY_PREFIX = "select * \n" +
+            "from flatedge \n" +
+            "left join acknowledge on flatedge.id = acknowledge.id \n";
+    
     
     /** The graph associated with this query */
     protected AmberGraph graph;
@@ -33,7 +38,7 @@ public class AmberQueryBase {
     
 
     
-    protected Map<Long, Map<String, Object>> getElementPropertyMaps(Handle h, String elementIdTable, String elementIdColumn) {
+    protected Map<Long, Map<String, Object>> getVertexPropertyMaps(Handle h, String elementIdTable, String elementIdColumn) {
         
         List<AmberVertex> vertices = h.createQuery(
                 String.format("%1$s inner join %2$s on %2$s.%3$s = node.id %n", VERTEX_QUERY_PREFIX, elementIdTable, elementIdColumn)).map(new AmberVertexMapper(graph)).list();
@@ -41,6 +46,18 @@ public class AmberQueryBase {
         Map<Long, Map<String, Object>> propertyMaps = new HashMap<Long, Map<String, Object>>();
         for (AmberVertex vertex : vertices) {
             propertyMaps.put((Long) vertex.getId(), vertex.getProperties());
+        }
+        return propertyMaps;
+    }
+
+    protected Map<Long, Map<String, Object>> getEdgePropertyMaps(Handle h, String elementIdTable, String elementIdColumn) {
+        
+        List<AmberEdge> edges = h.createQuery(
+                String.format("%1$s inner join %2$s on %2$s.%3$s = flatedge.id %n", EDGE_QUERY_PREFIX, elementIdTable, elementIdColumn)).map(new AmberEdgeMapper(graph, false)).list();
+
+        Map<Long, Map<String, Object>> propertyMaps = new HashMap<Long, Map<String, Object>>();
+        for (AmberEdge edge : edges) {
+            propertyMaps.put((Long) edge.getId(), edge.getProperties());
         }
         return propertyMaps;
     }
@@ -52,9 +69,9 @@ public class AmberQueryBase {
         List<Vertex> vertices = new ArrayList<>();
         List<AmberVertexWithState> wrappedVertices = h.createQuery(String.format(
                 "SELECT v.id, v.txn_start, v.txn_end, 'AMB' state "
-                + " FROM vertex v, %1$s "
+                + " FROM node v, %1$s "
                 + " WHERE "
-                + " v.txn_end = 0 AND v.id = %1$s.%2$s "
+                + " v.id = %1$s.%2$s "
                 + " ORDER BY %1$s.%3$s, %1$s.%2$s",
                 vertexIdTable, vertexIdColumn, vertexOrderColumn))
                 .map(new AmberVertexWithStateMapper(graph)).list();
@@ -102,9 +119,9 @@ public class AmberQueryBase {
         List<Edge> edges = new ArrayList<>();
         List<AmberEdgeWithState> wrappedEdges = h.createQuery(String.format(
                 "SELECT e.id, e.txn_start, e.txn_end, e.label, e.v_in, e.v_out, e.edge_order, 'AMB' state "
-                + " FROM edge e, %1$s "
-                + " WHERE e.txn_end = 0 "
-                + " AND e.id = %1$s.%2$s",
+                + " FROM flatedge e, %1$s "
+                + " WHERE "
+                + " e.id = %1$s.%2$s",
                 edgeIdTable, edgeIdColumn))
                 .map(new EdgeMapper(graph, true)).list();
         
@@ -150,9 +167,9 @@ public class AmberQueryBase {
 
         List<AmberEdgeWithState> wrappedEdges = h.createQuery(String.format(
                 "SELECT e.id, e.txn_start, e.txn_end, e.label, e.v_in, e.v_out, e.edge_order, 'AMB' state "
-                + " FROM edge e, %1$s, %3$s "
-                + " WHERE e.txn_end = 0 "
-                + " AND e.v_in = %1$s.%2$s "
+                + " FROM flatedge e, %1$s, %3$s "
+                + " WHERE "
+                + "     e.v_in = %1$s.%2$s "
                 + " AND e.v_out = %3$s.%4$s ",
                 inVertexIdTable, inVertexIdColumn, outVertexIdTable, outVertexIdColumn))
                 .map(new EdgeMapper(graph, true)).list();

--- a/src/main/java/amberdb/graph/AmberVertexQuery.java
+++ b/src/main/java/amberdb/graph/AmberVertexQuery.java
@@ -22,16 +22,6 @@ import amberdb.graph.dao.AmberDao;
 
 public class AmberVertexQuery extends AmberQueryBase {
     
-    static final String VERTEX_QUERY_PREFIX =              
-            "select * \n" +
-            "from node \n" +
-            "left join work        on        work.id = node.id \n" +
-            "left join file        on        file.id = node.id \n" +
-            "left join description on description.id = node.id \n" +
-            "left join party       on       party.id = node.id \n" +
-            "left join tag         on         tag.id = node.id \n";
- 
-	
     // limit the number of vertices returned by a query without criteria
     static final int MAX_VERTICES = 10000; 
     

--- a/src/main/java/amberdb/graph/AmberVertexQuery.java
+++ b/src/main/java/amberdb/graph/AmberVertexQuery.java
@@ -21,6 +21,16 @@ import amberdb.graph.dao.AmberDao;
 
 
 public class AmberVertexQuery extends AmberQueryBase {
+    
+    static final String VERTEX_QUERY_PREFIX =              
+            "select * \n" +
+            "from node \n" +
+            "left join work        on        work.id = node.id \n" +
+            "left join file        on        file.id = node.id \n" +
+            "left join description on description.id = node.id \n" +
+            "left join party       on       party.id = node.id \n" +
+            "left join tag         on         tag.id = node.id \n";
+ 
 	
     // limit the number of vertices returned by a query without criteria
     static final int MAX_VERTICES = 10000; 
@@ -104,17 +114,7 @@ public class AmberVertexQuery extends AmberQueryBase {
     
     
     protected String generateAndQuery() {
-        StringBuilder s = new StringBuilder();
-        s.append(
-        		"select * \n" +
-        		"from node \n" +
-        		"left join work        on        work.id = node.id \n" +
-        		"left join file        on        file.id = node.id \n" +
-        		"left join description on description.id = node.id \n" +
-        		"left join party       on       party.id = node.id \n" +
-        		"left join tag         on         tag.id = node.id \n" +
-        		"where \n");
-        
+        StringBuilder s = new StringBuilder(VERTEX_QUERY_PREFIX + "where \n");
         
         for (int i = 0; i < properties.size(); i++) {
         	String columnName = properties.get(i).getName();
@@ -135,14 +135,7 @@ public class AmberVertexQuery extends AmberQueryBase {
             if (AmberDao.nodeFields.contains(columnName)) {
                 columnName = "node." + columnName;
             }
-            s.append(
-            		"select * \n" +
-            		"from node \n" +
-            		"left join work        on        work.id = node.id \n" +
-            		"left join file        on        file.id = node.id \n" +
-            		"left join description on description.id = node.id \n" +
-            		"left join party       on       party.id = node.id \n" +
-            		"left join tag         on         tag.id = node.id \n" +
+            s.append(VERTEX_QUERY_PREFIX +
             		"where " + columnName + " = :value"+ i + " \n"
                     + "UNION ALL \n");
         }
@@ -155,14 +148,7 @@ public class AmberVertexQuery extends AmberQueryBase {
     protected String generateAllQuery() {
         
         StringBuilder s = new StringBuilder();
-        s.append(
-        		"select * \n" +
-        		"from node \n" +
-        		"left join work        on        work.id = node.id \n" +
-        		"left join file        on        file.id = node.id \n" +
-        		"left join description on description.id = node.id \n" +
-        		"left join party       on       party.id = node.id \n" +
-        		"left join tag         on         tag.id = node.id \n" +
+        s.append(VERTEX_QUERY_PREFIX +
                 "LIMIT " + MAX_VERTICES);
         return s.toString();        
     }
@@ -193,38 +179,23 @@ public class AmberVertexQuery extends AmberQueryBase {
             return getVertices(q.map(new AmberVertexMapper(graph)).list());
         }
     }
-    
-    
-
-
+ 
 	public List<Vertex> executeJsonValSearch(String name, String value) {
         // quote any characters that could cause issues with the regex matching - assumes we are performing an exact match on value
         for (String quote : Arrays.asList(".", "(", ")", "[", "]", "{", "}")) {
             value = value.replace(quote, "\\" + quote);
         }
 
-        List<Vertex> vertices;
-        try (Handle h = graph.dbi().open()) {
-            h.begin();
-            h.setTransactionIsolation(TransactionIsolationLevel.READ_COMMITTED);
-            h.execute("DROP " + graph.tempTableDrop + " TABLE IF EXISTS vp; CREATE TEMPORARY TABLE vp (id BIGINT) " + graph.tempTableEngine + ";");
-            Update q = h.createStatement(
-                    "INSERT INTO vp (id) \n"
-                    + "SELECT p.id \n"
-                    + "FROM property p \n"
-                    + "WHERE p.txn_end = 0 \n"
-                    + "AND p.name = :name " 
-                    + "AND p.value REGEXP :value");
-            q.bind("name", name);
-            q.bind("value", AmberProperty.encode("\"" + value + "\""));
-            q.execute();
-            h.commit();
-
-            // and reap the rewards
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "vp", "id");
-            vertices = getVertices(h, graph, propMaps, "vp", "id", "id");
+        String sql = VERTEX_QUERY_PREFIX + "where ";
+        if (AmberDao.nodeFields.contains(name)) {
+            sql += "node.";
         }
-        return vertices;
+        sql += name + " regexp :value";
+        
+        try (Handle h = graph.dbi().open()) {
+            Query<Map<String, Object>> q = h.begin().createQuery(sql).bind("value", value);
+            return getVertices(q.map(new AmberVertexMapper(graph)).list());
+        }
     }
 
 }

--- a/src/main/java/amberdb/query/ObjectsWithPropertyReportQuery.java
+++ b/src/main/java/amberdb/query/ObjectsWithPropertyReportQuery.java
@@ -67,7 +67,7 @@ public class ObjectsWithPropertyReportQuery extends AmberQueryBase {
             q.execute();
             h.commit();
 
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "vp", "id");
+            Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h, "vp", "id");
             vertices = getVertices(h, graph, propMaps, "vp", "id", "id");
         }
         return vertices;
@@ -161,7 +161,7 @@ public class ObjectsWithPropertyReportQuery extends AmberQueryBase {
             q.execute();
             h.commit();
 
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h,
+            Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h,
                     "er", "id");
             vertices = getVertices(h, graph, propMaps, "er", "id", "id");
 

--- a/src/main/java/amberdb/query/WorkChildrenQuery.java
+++ b/src/main/java/amberdb/query/WorkChildrenQuery.java
@@ -162,7 +162,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
                     .execute();
             h.commit();
             
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "v1", "id");
+            Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h, "v1", "id");
             vertices = getVertices(h, graph, propMaps, "v1", "id", "ord");
             
             for (Vertex v : vertices) {
@@ -239,7 +239,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
             h.createStatement(s.toString()).execute();
             h.commit();
 
-            Map<Long, Map<String, Object>> propMaps = getElementPropertyMaps(h, "v1", "id");
+            Map<Long, Map<String, Object>> propMaps = getVertexPropertyMaps(h, "v1", "id");
             vertices = getVertices(h, graph, propMaps, "v1", "id", "ord");
 
             for (Vertex v : vertices) {

--- a/src/test/java/amberdb/graph/AmberPropertyQueryTest.java
+++ b/src/test/java/amberdb/graph/AmberPropertyQueryTest.java
@@ -227,18 +227,21 @@ public class AmberPropertyQueryTest {
     public void testJsonListValueQueries() throws Exception {
 
         Vertex v1 = graph.addVertex(null);
-        v1.setProperty("json-list", "[\"abba\",\"beta\",\"delta\",\"gama\"]");
+        v1.setProperty("type", "work");
+        v1.setProperty("contributor", "[\"abba\",\"beta\",\"delta\",\"gamma\"]");
 
         Vertex v2 = graph.addVertex(null);
-        v2.setProperty("json-list", "[\"babba\",\"beta\",\"delta\",\"gama\"]");
+        v2.setProperty("type", "work");
+        v2.setProperty("contributor", "[\"babba\",\"beta\",\"delta\",\"gamma\"]");
 
         Vertex v3 = graph.addVertex(null);
-        v3.setProperty("json-list", "[\"beta\",\"delta\",\"gama\", \"abba\"]");
+        v3.setProperty("type", "work");
+        v3.setProperty("contributor", "[\"beta\",\"delta\",\"gamma\", \"abba\"]");
 
         graph.commit("tester", "saving some vertices with properties");
 
         AmberVertexQuery avq = graph.newVertexQuery();
-        List<Vertex> results = avq.executeJsonValSearch("json-list", "abba");
+        List<Vertex> results = avq.executeJsonValSearch("contributor", "\"abba\"");
 
         assertEquals(2, results.size());
         assertTrue(results.remove(v1));

--- a/src/test/java/amberdb/model/WorkAcknowledgementTest.java
+++ b/src/test/java/amberdb/model/WorkAcknowledgementTest.java
@@ -1,36 +1,26 @@
 package amberdb.model;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.sql.DataSource;
-
-import amberdb.AbstractDatabaseIntegrationTest;
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 
-import amberdb.AmberDb;
+import amberdb.AbstractDatabaseIntegrationTest;
 import amberdb.AmberSession;
-import amberdb.cli.Main;
 import amberdb.relation.Acknowledge;
 
 public class WorkAcknowledgementTest extends AbstractDatabaseIntegrationTest {
@@ -59,7 +49,7 @@ public class WorkAcknowledgementTest extends AbstractDatabaseIntegrationTest {
                 assertEquals(ack.getAckType(), type);
                 assertEquals(ack.getKindOfSupport(), kindOfSupport);
                 assertEquals(ack.getWeighting(), weighting);
-                assertEquals(ack.getDate(), date);
+                assertTrue(Math.abs(ack.getDate().getTime() - date.getTime()) < 1000);
                 assertEquals(ack.getUrlToOriginal(), url);
             }
         }


### PR DESCRIPTION
DSCS-2367 Update AmberMultipartQuery.java to use AmberDB v2 tables
DSCS-2368 Update AmberQuery.java to use AmberDB v2 tables
DSCS-2369 Update AmberQueryBase.java to use AmberDB v2 tables
DSCS-2370 Update AmberVertexQuery.java to use AmberDB v2 tables

@scoen @yetti @ninhnguyen @shuangzhou @weijunnla @m-r-c 