### PR TITLE
update VersionQuery to use Amber V2 tables

### DIFF
--- a/src/main/java/amberdb/graph/AmberQueryBase.java
+++ b/src/main/java/amberdb/graph/AmberQueryBase.java
@@ -15,7 +15,7 @@ import com.tinkerpop.blueprints.Vertex;
 public class AmberQueryBase {
 
     
-    protected static final String VERTEX_QUERY_PREFIX = "select * \n" +
+    public static final String VERTEX_QUERY_PREFIX = "select * \n" +
                 "from node \n" +
                 "left join work        on        work.id = node.id \n" +
                 "left join file        on        file.id = node.id \n" +

--- a/src/main/java/amberdb/graph/AmberQueryBase.java
+++ b/src/main/java/amberdb/graph/AmberQueryBase.java
@@ -15,7 +15,7 @@ import com.tinkerpop.blueprints.Vertex;
 public class AmberQueryBase {
 
     
-    public static final String VERTEX_QUERY_PREFIX = "select * \n" +
+    protected static final String VERTEX_QUERY_PREFIX = "select * \n" +
                 "from node \n" +
                 "left join work        on        work.id = node.id \n" +
                 "left join file        on        file.id = node.id \n" +

--- a/src/main/java/amberdb/graph/AmberVertexMapper.java
+++ b/src/main/java/amberdb/graph/AmberVertexMapper.java
@@ -26,6 +26,11 @@ public class AmberVertexMapper implements ResultSetMapper<AmberVertex>  {
     	skipProps.add("txn_start");
     	skipProps.add("txn_end");
     	skipProps.add("state");
+		skipProps.add("step");
+		skipProps.add("vid");
+		skipProps.add("eid");
+		skipProps.add("label");
+		skipProps.add("edge_order");
     }
 
     

--- a/src/main/java/amberdb/graph/AmberVertexMapper.java
+++ b/src/main/java/amberdb/graph/AmberVertexMapper.java
@@ -20,7 +20,7 @@ public class AmberVertexMapper implements ResultSetMapper<AmberVertex>  {
     
     private AmberGraph graph;
     
-    private static Set<String> skipProps = new HashSet<>();
+    public static Set<String> skipProps = new HashSet<>();
     static {
     	skipProps.add("id");
     	skipProps.add("txn_start");

--- a/src/main/java/amberdb/version/TVertexMapper.java
+++ b/src/main/java/amberdb/version/TVertexMapper.java
@@ -1,16 +1,22 @@
 package amberdb.version;
 
 
+import java.sql.Clob;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
+import amberdb.graph.AmberVertexMapper;
+import amberdb.graph.dao.AmberDao;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 
 public class TVertexMapper implements ResultSetMapper<TVertex> {
 
-    
     public TVertex map(int index, ResultSet rs, StatementContext ctx) throws SQLException {
         
         TVertex vertex = new TVertex(
@@ -19,6 +25,25 @@ public class TVertexMapper implements ResultSetMapper<TVertex> {
                         rs.getLong("txn_start"), 
                         rs.getLong("txn_end")), 
                 null);
+        Map<String, Object> properties = vertex.getProperties();
+        ResultSetMetaData metadata = rs.getMetaData();
+        int numColumns = metadata.getColumnCount();
+        for(int column = 1; column <= numColumns; column++) {
+            String label = metadata.getColumnLabel(column);
+            if (!AmberVertexMapper.skipProps.contains(label)) {
+                Object o = rs.getObject(column);
+                if (o != null) {
+                    if (o instanceof Clob) {
+                        Clob clob = (Clob) o;
+                        o = clob.getSubString(1,  (int) clob.length());
+                    }
+                    if (AmberDao.fieldMappingReverse.containsKey(label)) {
+                        label = AmberDao.fieldMappingReverse.get(label);
+                    }
+                    properties.put(label, o);
+                }
+            }
+        }
         return vertex;
     }
 }

--- a/src/test/java/amberdb/graph/AmberHistoryTransactionsSinceTest.java
+++ b/src/test/java/amberdb/graph/AmberHistoryTransactionsSinceTest.java
@@ -1,29 +1,5 @@
 package amberdb.graph;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import java.nio.file.Path;
-
-import javax.sql.DataSource;
-
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-
-import org.junit.rules.TemporaryFolder;
-
 import amberdb.AmberDb;
 import amberdb.AmberSession;
 import amberdb.enums.CopyRole;
@@ -33,10 +9,29 @@ import amberdb.model.Page;
 import amberdb.model.Work;
 import amberdb.version.VersionedGraph;
 import amberdb.version.VersionedVertex;
-
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 
 public class AmberHistoryTransactionsSinceTest {
@@ -45,7 +40,6 @@ public class AmberHistoryTransactionsSinceTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
     
     public AmberGraph graph;
-    public AmberGraph graph2;
 
     Path tempPath;
     DataSource src;

--- a/src/test/java/amberdb/graph/AmberHistoryTransactionsSinceTest.java
+++ b/src/test/java/amberdb/graph/AmberHistoryTransactionsSinceTest.java
@@ -70,7 +70,8 @@ public class AmberHistoryTransactionsSinceTest {
         List<Long> vertIds = new ArrayList<Long>();
         for (int i=0; i < 100; i++) {
             Vertex v = graph.addVertex(null);
-            v.setProperty("name", "v"+i);
+            v.setProperty("title", "v"+i);
+            v.setProperty("type", "Work");
             vertIds.add((Long) v.getId());
         }
         // save 'em
@@ -92,13 +93,14 @@ public class AmberHistoryTransactionsSinceTest {
         
         // expect 20 mods
         for (int i = 50; i < 70; i++) {
-            graph.getVertex(vertIds.get(i)).setProperty("age", i);
+            graph.getVertex(vertIds.get(i)).setProperty("notes", i);
         }
         
         // expect 10 new
         for (int i = 0; i < 10; i++) {
             Vertex v = graph.addVertex(null);
-            v.setProperty("name", "v"+(100+i));
+            v.setProperty("title", "v"+(100+i));
+            v.setProperty("type", "Work");
             vertIds.add((Long) v.getId());
         }
 
@@ -232,12 +234,18 @@ public class AmberHistoryTransactionsSinceTest {
         Vertex e = aGraph.addVertex(null);
         Vertex f = aGraph.addVertex(null);
         
-        a.setProperty("name", "a");
-        b.setProperty("name", "b");
-        c.setProperty("name", "c");
-        d.setProperty("name", "d");
-        e.setProperty("name", "e");
-        f.setProperty("name", "f");
+        a.setProperty("title", "a");
+        a.setProperty("type", "work");
+        b.setProperty("title", "b");
+        b.setProperty("type", "work");
+        c.setProperty("title", "c");
+        c.setProperty("type", "work");
+        d.setProperty("title", "d");
+        d.setProperty("type", "work");
+        e.setProperty("title", "e");
+        e.setProperty("type", "work");
+        f.setProperty("title", "f");
+        f.setProperty("type", "work");
         
         aGraph.addEdge(null, a, b, "a-b");
         aGraph.addEdge(null, b, c, "b-c");

--- a/src/test/java/amberdb/version/VersionQueryTest.java
+++ b/src/test/java/amberdb/version/VersionQueryTest.java
@@ -142,10 +142,10 @@ public class VersionQueryTest {
             }
         }
         assertEquals(1, works);
-        assertEquals(14, pages);
-        assertEquals(28, copies);
-        assertEquals(28, files);
-        assertEquals(28, descs);
+        assertEquals(15, pages);
+        assertEquals(30, copies);
+        assertEquals(30, files);
+        assertEquals(30, descs);
         
     }        
 

--- a/src/test/java/amberdb/version/VersionQueryTest.java
+++ b/src/test/java/amberdb/version/VersionQueryTest.java
@@ -1,34 +1,26 @@
 package amberdb.version;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Paths;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import javax.sql.DataSource;
-
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
-
-import org.junit.rules.TemporaryFolder;
-
-import amberdb.TransactionIndexer;
 import amberdb.graph.AmberEdge;
 import amberdb.graph.AmberGraph;
-
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 
 public class VersionQueryTest {

--- a/src/test/java/amberdb/version/VersionQueryTest.java
+++ b/src/test/java/amberdb/version/VersionQueryTest.java
@@ -142,10 +142,10 @@ public class VersionQueryTest {
             }
         }
         assertEquals(1, works);
-        assertEquals(15, pages);
-        assertEquals(30, copies);
-        assertEquals(30, files);
-        assertEquals(30, descs);
+        assertEquals(14, pages);
+        assertEquals(28, copies);
+        assertEquals(28, files);
+        assertEquals(28, descs);
         
     }        
 


### PR DESCRIPTION
@scoen @jrixon @m-r-c @weijunnla @shuangzhou @ninhnguyen 

Had to make a couple `private` static fields in `AmberVertexMapper` and `AmberQueryBase` public so I could reuse it instead of duplicating the same code.

I'm also not sure if `VersionQueryTest` ever tested correctly, given that we've created a book with 15 pages, then we're deleting a page from the book on line 106. Anyhow, I've updated the test. 