### PR TITLE
DSCS-2523 changes all history queries to sort by transaction time fir…

### DIFF
--- a/src/main/java/amberdb/AmberSession.java
+++ b/src/main/java/amberdb/AmberSession.java
@@ -208,6 +208,15 @@ public class AmberSession implements AutoCloseable {
     /**
      * commit saves everything in the current session and records who did it and why with the transaction record.
      *
+     * @param why the operation being performed when the transaction was committed
+     */
+    public Long commit(String why) {
+        return commit("amberdb", why);
+    }
+
+    /**
+     * commit saves everything in the current session and records who did it and why with the transaction record.
+     *
      * @param who the username to associate with the transaction
      * @param why the operation they were fulfilling by commiting the transaction
      */

--- a/src/main/java/amberdb/graph/dao/AmberDao.java
+++ b/src/main/java/amberdb/graph/dao/AmberDao.java
@@ -1187,7 +1187,7 @@ public abstract class AmberDao implements Transactional<AmberDao>, GetHandle {
             + "FROM transaction t, node_history v "
             + "WHERE v.id = :id "
             + "AND t.id = v.txn_end) "
-            + "ORDER BY id")
+            + "ORDER BY time, id")
     @Mapper(TransactionMapper.class)
     public abstract List<AmberTransaction> getTransactionsByVertexId(@Bind("id") Long id);
 
@@ -1201,7 +1201,7 @@ public abstract class AmberDao implements Transactional<AmberDao>, GetHandle {
             + "FROM transaction t, flatedge_history e "
             + "WHERE e.id = :id "
             + "AND t.id = e.txn_end) "
-            + "ORDER BY id")
+            + "ORDER BY time, id")
     @Mapper(TransactionMapper.class)
     public abstract List<AmberTransaction> getTransactionsByEdgeId(@Bind("id") Long id);
 

--- a/src/main/java/amberdb/query/ObjectsQuery.java
+++ b/src/main/java/amberdb/query/ObjectsQuery.java
@@ -127,21 +127,23 @@ public class ObjectsQuery extends AmberQueryBase {
                             "(\n" + 
                             "    SELECT a.id,\n" + 
                             "    (\n" + 
-                            "      SELECT b.txn_start FROM node_history b\n" +
+                            "      SELECT b.txn_start FROM node_history b, transaction t\n" +
                             "      WHERE a.id = b.id\n" + 
-                            "      ORDER BY b.txn_start DESC\n" + 
+                            "           and t.id = b.txn_start\n" +
+                            "      ORDER BY t.time DESC, b.txn_start DESC\n" +
                             "      LIMIT 1\n" + 
                             "    ) as txn_start,\n" + 
                             "    (\n" + 
-                            "      SELECT b.txn_end FROM node_history b\n" +
-                            "      WHERE a.id = b.id\n" + 
-                            "      ORDER BY b.txn_start DESC\n" + 
+                            "      SELECT b.txn_end FROM node_history b, transaction t\n" +
+                            "      WHERE a.id = b.id\n" +
+                            "           and t.id = b.txn_start\n" +
+                            "      ORDER BY t.time DESC, b.txn_start DESC\n" +
                             "      LIMIT 1\n" + 
                             "    ) as txn_end,\n" + 
                             "    (\n" + 
                             "      SELECT count(id) FROM node_history b\n" +
-                            "      WHERE a.id = b.id AND b.txn_start < @start_transaction\n" + 
-                            "    ) as v_count_before\n" + 
+                            "      WHERE a.id = b.id AND b.txn_start < @start_transaction\n" +
+                            "    ) as v_count_before\n" +
                             "    FROM v0 a\n" + 
                             "    ORDER BY id\n" + 
                             ") AS vertices_with_transition;"

--- a/src/main/java/amberdb/query/WorksQuery.java
+++ b/src/main/java/amberdb/query/WorksQuery.java
@@ -150,7 +150,7 @@ public class WorksQuery {
             String sql = "" +
                     "SELECT t1.time, t1.user, t1.operation, t2.transaction_id, t2.vertex_id " +
                     "FROM transaction t1, " +
-                    " (SELECT MAX(t.id) transaction_id, v.id vertex_id from transaction t, node v " +
+                    " (SELECT t.id transaction_id, v.id vertex_id from transaction t, node v ORDER BY t.time DESC, t.id DESC LIMIT 1" +
                     " WHERE t.id = v.txn_start and v.id in (" + Joiner.on(",").join(workIds) + ") group by v.id) t2 " +
                     "WHERE t1.id = t2.transaction_id ";
             return getTransactions(sess, sql);

--- a/src/main/java/amberdb/version/TEdgeMapper.java
+++ b/src/main/java/amberdb/version/TEdgeMapper.java
@@ -22,7 +22,8 @@ public class TEdgeMapper implements ResultSetMapper<TEdge> {
                 new TId(
                         rs.getLong("id"),
                         rs.getLong("txn_start"), 
-                        rs.getLong("txn_end")),
+                        rs.getLong("txn_end"),
+                        rs.getLong("time")),
                 rs.getString("label"), 
                 rs.getLong("v_out"), 
                 rs.getLong("v_in"), 

--- a/src/main/java/amberdb/version/TId.java
+++ b/src/main/java/amberdb/version/TId.java
@@ -6,24 +6,25 @@ public class TId implements Comparable<TId> {
     Long id;
     Long start = 0l;
     Long end = 0l;
-    
+    Long time;
     
     public TId(Long id) {
         this.id = id;
     }
 
     
-    public TId(Long id, Long start, Long end) {
+    public TId(Long id, Long start, Long end, Long time) {
         this.id = id;
         this.start = start;
         this.end = end;
+        this.time = time;
     }
     
     
     public static TId parse(String idStr) throws InvalidIdentifierException {
         try {
-            String[] parts = idStr.split(":", 3);
-            return new TId(Long.parseLong(parts[0]), Long.parseLong(parts[1]), Long.parseLong(parts[2]));
+            String[] parts = idStr.split(":", 4);
+            return new TId(Long.parseLong(parts[0]), Long.parseLong(parts[1]), Long.parseLong(parts[2]), Long.parseLong(parts[3]));
         } catch (Exception e) {
             throw new InvalidIdentifierException("Cannot parse as TId: " + idStr, e);
         }
@@ -54,6 +55,8 @@ public class TId implements Comparable<TId> {
     public int compareTo(TId o) {
         if (id > o.id) return 1;
         if (id < o.id) return -1;
+        if (time > o.time) return 1;
+        if (time < o.time) return -1;
         if (start > o.start) return 1;
         if (start < o.start) return -1;
         

--- a/src/main/java/amberdb/version/TPropertyMapper.java
+++ b/src/main/java/amberdb/version/TPropertyMapper.java
@@ -19,7 +19,8 @@ public class TPropertyMapper implements ResultSetMapper<TProperty> {
         Long id = rs.getLong("id"); 
         Long start = rs.getLong("txn_start"); 
         Long end = rs.getLong("txn_end"); 
-        TId vId = new TId(id, start, end);
+        Long time = rs.getLong("time");
+        TId vId = new TId(id, start, end, time);
         
         String name =rs.getString("name");
         DataType type = DataType.valueOf(rs.getString("type"));

--- a/src/main/java/amberdb/version/TVertexMapper.java
+++ b/src/main/java/amberdb/version/TVertexMapper.java
@@ -23,7 +23,8 @@ public class TVertexMapper implements ResultSetMapper<TVertex> {
                 new TId(
                         rs.getLong("id"), 
                         rs.getLong("txn_start"), 
-                        rs.getLong("txn_end")), 
+                        rs.getLong("txn_end"),
+                        rs.getLong("time")),
                 null);
         Map<String, Object> properties = vertex.getProperties();
         ResultSetMetaData metadata = rs.getMetaData();

--- a/src/main/java/amberdb/version/dao/VersionDao.java
+++ b/src/main/java/amberdb/version/dao/VersionDao.java
@@ -15,13 +15,14 @@ public interface VersionDao extends Transactional<VersionDao> {
             "SELECT id "
             + "FROM transaction " 
             + "WHERE time > :time "
-            + "ORDER BY id")
+            + "ORDER BY time, id")
     List<Long> getTransactionsSince(
             @Bind("time") Long time);
 
     @SqlQuery("SELECT id "
              + "FROM transaction "
-             + "WHERE time > :startTime and time < :endTime")
+             + "WHERE time > :startTime and time < :endTime "
+             + "ORDER BY time, id ")
     List<Long> getTransactionsBetween(@Bind("startTime") Long startTime, @Bind("endTime") Long endTime);
     
     


### PR DESCRIPTION
…st, then id, to ensure transactions are ordered by the time they were written to the database, not the time the id was assigned (which can be some time before the actual, write depending on the session size).

See http://ourweb.nla.gov.au/apps/jira/browse/DSCS-2523 for a description of why this was a problem.

@scoen @ninhnguyen @jrixon @shuangzhou @adityaburra @weijunnla 