### PR TITLE
A work around to get children in order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>au.gov.nla</groupId>
     <artifactId>amberdb</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>amberdb</name>
     <description>Digital library domain model</description>

--- a/src/main/java/amberdb/query/WorkChildrenQuery.java
+++ b/src/main/java/amberdb/query/WorkChildrenQuery.java
@@ -154,7 +154,7 @@ public class WorkChildrenQuery extends AmberQueryBase {
         " AND e.label = 'isPartOf' " +
         " AND p.id = v.id " +
         " AND p.type IN " + workNotSectionInList + " " +
-        " ORDER BY e.edge_order " +
+        " ORDER BY e.edge_order, e.id " +
         " LIMIT " + start + "," + num + "; ";
     }
     


### PR DESCRIPTION
@scoen @sjacob @m-r-c @shuangzhou 
This is a work around to get children of a work in order.
For some reason, the edge_orders of children of some works are the same, eg.
select * from flatedge where v_in = 38235327 order by edge_order;
The edge_order is 1 for all children.
The DISTINCT in the query causes the query to result in a list of arbitrary order children.
The work around is to add the flatedge id as the second sort param, with the assumption that an edge with a lower id is added before one with a higher id.