### PR TITLE
DA-8 Adds "Access only" copy for preservica-managed material to indic…

### DIFF
--- a/src/main/java/amberdb/enums/CopyRole.java
+++ b/src/main/java/amberdb/enums/CopyRole.java
@@ -31,6 +31,7 @@ public enum CopyRole {
     WORKING_COPY("w", "Working",11, false),
     ANALOGUE_DISTRIBUTION_COPY("ad", "Analogue distribution",12, false),
     ACCESS_COPY("ac", "Access",130, false),
+    ACCESS_ONLY_COPY ("ao", "Access-only copy", 135, false),
     ARCHIVE_COPY("a", "Archive",140, false),
     EDITED_COPY("ed", "Edited",150, false),
     ELECTRONIC_SUMMARY("se", "Electronic summary", "No",160, false),

--- a/src/test/java/amberdb/enums/CopyRoleTest.java
+++ b/src/test/java/amberdb/enums/CopyRoleTest.java
@@ -93,6 +93,7 @@ public class CopyRoleTest {
         assertEquals(11,CopyRole.WORKING_COPY.ord());
         assertEquals(12,CopyRole.ANALOGUE_DISTRIBUTION_COPY.ord());
         assertEquals(130,CopyRole.ACCESS_COPY.ord());
+        assertEquals(135,CopyRole.ACCESS_ONLY_COPY.ord());
         assertEquals(140,CopyRole.ARCHIVE_COPY.ord());
         assertEquals(150,CopyRole.EDITED_COPY.ord());
         assertEquals(160,CopyRole.ELECTRONIC_SUMMARY.ord());
@@ -137,7 +138,7 @@ public class CopyRoleTest {
         assertEquals(485,CopyRole.UNKNOWN_COPY.ord());
         assertEquals(490,CopyRole.VIEW_COPY.ord());
         assertEquals(500,CopyRole.VISUAL_NAVIGATION_DELIVERY_COPY.ord());
-        assertEquals(58,CopyRole.values().length);
+        assertEquals(59,CopyRole.values().length);
     }
     
     private void compareItemsBefore(int index, List<CopyRole> roles) {        


### PR DESCRIPTION
…ate the the access copy is held by DLC but the original is held by Preservica

See also:
- Catalogue Sync: https://github.com/nla/dl-catalogue-sync/pull/13
- TroveService: https://github.com/nla/dl-trove-service/pull/93

@ninhnguyen @sjacob @adityaburra @scoen @nlahuwgeddes 