### PR TITLE
DA-1 & 6 adds support for ingesting Preservica Access-Only copies

### DIFF
--- a/src/main/java/amberdb/model/Work.java
+++ b/src/main/java/amberdb/model/Work.java
@@ -1942,6 +1942,7 @@ public interface Work extends Node {
         @Override
         public boolean hasImageAccessCopy(){
             Copy accessCopy = getCopy(CopyRole.ACCESS_COPY);
+            accessCopy = accessCopy == null ? getCopy(CopyRole.ACCESS_ONLY_COPY) : null;
             return accessCopy != null && accessCopy.getImageFile() != null;
         }
 

--- a/src/main/java/amberdb/util/RepresentativeImageHelper.java
+++ b/src/main/java/amberdb/util/RepresentativeImageHelper.java
@@ -52,6 +52,9 @@ public class RepresentativeImageHelper {
         Copy accessCopy = work.getCopy(CopyRole.ACCESS_COPY);
         if (accessCopy != null && accessCopy.getImageFile() != null) {
             return work;
+        } else if (accessCopy == null) {
+            Copy accessOnlyCopy = work.getCopy(CopyRole.ACCESS_ONLY_COPY);
+            return accessOnlyCopy != null && accessOnlyCopy.getImageFile() != null ? work : null;
         }
         return null;
     }


### PR DESCRIPTION
This updates the mass digi EAD and generic jobs to allow Access-Only copies to be ingested.

See https://ourweb.nla.gov.au/apps/jira/browse/DA-1 and https://ourweb.nla.gov.au/apps/jira/browse/DA-6 for details.

See also:
- https://github.com/nla/banjo-job/pull/21
- https://github.com/nla/banjo/pull/2959
- https://github.com/nla/banjo-common/pull/26

@adityaburra @ninhnguyen @scoen @sjacob @nlahuwgeddes 