### PR TITLE
DL-54: Quote white spaces so that they aren't ignored in the sort

### DIFF
--- a/src/main/java/amberdb/model/sort/WorkComparator.java
+++ b/src/main/java/amberdb/model/sort/WorkComparator.java
@@ -55,11 +55,11 @@ public class WorkComparator implements Comparator<Work> {
             if (o1.equals("[]")) return 1;
         }
 
-     // easy comparisons for Strings, Booleans, Dates and a variety of number formats
+        // easy comparisons for Strings, Booleans, Dates and a variety of number formats
         if (o1 instanceof String){
-            int i = NaturalSort.compareNatural((String)o1, (String)o2);
+            int i = NaturalSort.compareNatural(((String)o1).replaceAll("(\\s+)", "' '"), ((String)o2).replaceAll("(\\s+)", "' '"));
             return sortForward ? i : -i;
-        }else if (o1 instanceof Comparable) {
+        } else if (o1 instanceof Comparable) {
             int i = ((Comparable) o1).compareTo(o2);
             return sortForward ? i : -i;
         }


### PR DESCRIPTION
NaturalSort uses RuleBasedCollator (https://docs.oracle.com/javase/8/docs/api/index.html?java/text/RuleBasedCollator.html) which ignores white spaces when doing the sorting. The work around is to turn white spaces into a single quoted space to make the sort behaves correctly.
@m-r-c @adityaburra @sjacob 