### PR TITLE
DL-60: Added support for calculation duration of Moving Image

### DIFF
--- a/src/main/java/amberdb/graph/AmberPreCommitHook.java
+++ b/src/main/java/amberdb/graph/AmberPreCommitHook.java
@@ -18,13 +18,16 @@ public abstract class AmberPreCommitHook<T> {
             Section.class.getAnnotation(TypeValue.class).value()
     ).build();
 
-    public static List<String> COPY_TYPES= ImmutableList.<String>builder().add(
+    public static List<String> COPY_TYPES = ImmutableList.<String>builder().add(
             Copy.class.getAnnotation(TypeValue.class).value()
     ).build();
 
-
-    public static List<String> SOUND_FILE_TYPES= ImmutableList.<String>builder().add(
+    public static List<String> SOUND_FILE_TYPES = ImmutableList.<String>builder().add(
             SoundFile.class.getAnnotation(TypeValue.class).value()
+    ).build();
+
+    public static List<String> MOVINGIMAGE_FILE_TYPES = ImmutableList.<String>builder().add(
+            MovingImageFile.class.getAnnotation(TypeValue.class).value()
     ).build();
 
     public abstract boolean shouldHook(List<T> added, List<T> modified, List<T> deleted);


### PR DESCRIPTION
The calculation of duration only applies to Sound material type.  Extended it to include Moving Image (DL-60).
@nlahuwgeddes @adityaburra @m-r-c @sjacob 